### PR TITLE
Persist KV cache on disk

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
                 .product(name: "MLXFast", package: "mlx-swift"),
                 .product(name: "Transformers", package: "swift-transformers"),
             ],
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            swiftSettings: [.swiftLanguageMode(.v5)],
+            linkerSettings: [.linkedLibrary("sqlite3")]
         ),
         .target(
             name: "SlotstreamDiagnostics",

--- a/Sources/Slotstream/ChunkIndex.swift
+++ b/Sources/Slotstream/ChunkIndex.swift
@@ -1,0 +1,381 @@
+// Chunk index for the disk-persisted prefix KV cache.
+//
+// One node = one chunk's append-only attention state plus the recurrent state
+// at its endpoint. Prefill nodes normally end at `prefillChunk` boundaries;
+// terminal decode nodes may have any positive length. Nodes are chained by
+// parent: chunk N's key is
+// `sha256(parent_sha || sha256(chunk_embeddings))`, so two conversations
+// that share a parent but diverge in the next token range get distinct keys
+// and never alias.
+//
+// On disk, each chunk lives at `kvcache_dir/<key>/` with three files:
+//   - `data.kv` — the chunk delta plus endpoint recurrent state
+//   - `parent_sha.bin` — parent key as hex UTF-8 (or empty at the root)
+//   - `emb_sha.bin` — embedding hash as hex UTF-8
+//
+// The metadata DB (SQLite, journal_mode=WAL) holds:
+//   - last_used: timestamp of most recent save or load
+//   - size_bytes: total bytes occupied by this chunk's directory
+//   - parent_sha: parent's key (NULL for depth 0)
+//
+// Eviction: when total size exceeds the quota (--kv-cache-size, else env
+// SLOTSTREAM_KVCACHE_MAX_GB, default 20), the saver deletes a forest of
+// leaves (and orphans whose parent is gone) whose combined size clears the
+// deficit, choosing the lowest-value chunks first (where a chunk's value is
+// the max of its own and all its descendants' last_used, so leaves with live
+// children are protected). DiskCache.enforceQuota runs the same pass at
+// startup when the CLI flag lowers the quota; it also sweeps the evicted
+// chunks' directories off the disk.
+//
+// Crashes mid-save leave a `.kv.partial` file in the chunk directory; the
+// next save for that key detects the partial and rewrites. The metadata DB
+// is updated only after the `.kv.partial` is renamed atomically to `data.kv`,
+// so a crash before rename leaves no DB row pointing at partial data.
+
+import Foundation
+import CryptoKit
+import SQLite3
+
+/// Process-wide SQLite handle. Single connection per process; serialized
+/// internally. WAL mode tolerates concurrent readers (future split: stats
+/// tool) but writers serialize, which is what we want.
+public final class ChunkIndex {
+    /// Process-wide index singleton. Public so CLI-side checks can exercise
+    /// the eviction policy without a model; the DB opens at DiskCache.dir on
+    /// first touch, so overrides must be applied before the first use.
+    public static let shared = ChunkIndex()
+
+    /// Model-identity namespace, mixed into every key at depth 0. Set by the
+    /// model when it loads (from config.json + the weight shard sizes). The
+    /// key already hashes chunk embeddings, so tokenizer/embedding drift
+    /// changes every key on its own; this catches a same-shape weight swap
+    /// (re-quantized revision) that would otherwise serve stale KV built by
+    /// different attention/MLP weights. Empty until a model loads, which is
+    /// also when nothing can save or load yet.
+    public static var vault = ""
+
+    private var db: OpaquePointer?
+    private let serial = DispatchQueue(label: "slotstream.chunkindex")
+    private let dbPath: URL
+
+    private init() {
+        dbPath = DiskCache.dir.appendingPathComponent("metadata.db")
+        try? FileManager.default.createDirectory(
+            at: DiskCache.dir, withIntermediateDirectories: true)
+        if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
+            FileHandle.standardError.write(
+                Data("[kvcache] metadata.db open failed: \(String(cString: sqlite3_errmsg(db))) — disk cache disabled\n".utf8))
+            db = nil
+            return
+        }
+        // WAL: readers don't block writers, one writer at a time.
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL;", nil, nil, nil)
+        sqlite3_exec(db, "PRAGMA synchronous=NORMAL;", nil, nil, nil)
+        sqlite3_exec(db, "PRAGMA foreign_keys=ON;", nil, nil, nil)
+        let schema = """
+        CREATE TABLE IF NOT EXISTS chunks (
+          key TEXT PRIMARY KEY,
+          parent_sha TEXT,
+          depth INTEGER NOT NULL,
+          parent_token_count INTEGER,
+          token_count INTEGER,
+          size_bytes INTEGER NOT NULL,
+          last_used REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS chunks_parent ON chunks(parent_sha);
+        CREATE INDEX IF NOT EXISTS chunks_last_used ON chunks(last_used);
+        """
+        // No FK on parent_sha: a child chunk can be inserted before its
+        // parent (both are queued together in the save path), and SQLite's
+        // foreign_keys check would reject the child until the parent's row
+        // is visible. The chain walk stops at the first missing key anyway,
+        // so the orphan is harmless — sweepOrphans() drops it on the next
+        // eviction pass if nothing reconciles it.
+        sqlite3_exec(db, "PRAGMA foreign_keys=OFF;", nil, nil, nil)
+        if sqlite3_exec(db, schema, nil, nil, nil) != SQLITE_OK {
+            FileHandle.standardError.write(
+                Data("[kvcache] schema init failed: \(String(cString: sqlite3_errmsg(db)))\n".utf8))
+        }
+        // Existing v4 indexes predate variable-length terminal nodes. Nullable
+        // columns keep those rows readable while new saves populate boundaries.
+        sqlite3_exec(db, "ALTER TABLE chunks ADD COLUMN parent_token_count INTEGER;", nil, nil, nil)
+        sqlite3_exec(db, "ALTER TABLE chunks ADD COLUMN token_count INTEGER;", nil, nil, nil)
+        sqlite3_exec(
+            db,
+            "CREATE INDEX IF NOT EXISTS chunks_boundary ON chunks(parent_sha, parent_token_count, token_count);",
+            nil, nil, nil)
+    }
+
+    deinit { if db != nil { sqlite3_close(db) } }
+
+    /// Derive the model-identity namespace from the checkout that will build
+    /// the states saved under it: a hash of config.json plus the weight shard
+    /// sizes (name + byte count). Call once from Qwen4ExpModel.init, before
+    /// any save or load can run.
+    public static func setVault(modelDir: URL) {
+        var parts: [String] = []
+        let fm = FileManager.default
+        if let cfg = try? Data(contentsOf: modelDir.appendingPathComponent("config.json")) {
+            let digest = SHA256.hash(data: cfg)
+            parts.append(digest.map { String(format: "%02x", $0) }.joined())
+        }
+        if let shards = try? fm.contentsOfDirectory(
+            at: modelDir, includingPropertiesForKeys: [.fileSizeKey])
+        {
+            for shard in shards.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+            where shard.lastPathComponent.hasPrefix("model")
+                && shard.pathExtension == "safetensors"
+            {
+                let size = (try? shard.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                parts.append("\(shard.lastPathComponent):\(size)")
+            }
+        }
+        vault = parts.joined(separator: ",")
+    }
+
+    /// Stable key derivation. `parentSha` is nil for depth 0. The vault
+    /// namespace is mixed in before the chain so a different model identity
+    /// can never collide with this one at any depth.
+    public static func makeKey(parentSha: String?, embeddings: [Float]) -> String {
+        var hasher = SHA256()
+        if !vault.isEmpty {
+            hasher.update(data: Data("vault=\(vault.count)".utf8))
+            hasher.update(data: Data(vault.utf8))
+        }
+        if let p = parentSha { hasher.update(data: Data(p.utf8)) }
+        // Hash the embeddings in deterministic little-endian order. The caller
+        // passes a flat [Float] slice of the chunk's dequantized embedding
+        // matrix; any byte-identical prefix produces the same hash, so the
+        // chain matches across processes that re-derive from the same weights.
+        let n = embeddings.count
+        var buf = Data(capacity: n * 4)
+        for v in embeddings {
+            var f = v.bitPattern.littleEndian
+            withUnsafeBytes(of: &f) { buf.append(contentsOf: $0) }
+        }
+        hasher.update(data: buf)
+        let digest = hasher.finalize()
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Record a freshly saved chunk. Returns the resolved key (caller needs
+    /// it to write the parent_sha.bin and emb_sha.bin files).
+    public func register(
+        key: String, parentSha: String?, depth: Int,
+        parentTokenCount: Int, tokenCount: Int, sizeBytes: Int
+    ) {
+        serial.sync {
+            let stmt = prepare("""
+            INSERT INTO chunks(
+              key, parent_sha, depth, parent_token_count, token_count,
+              size_bytes, last_used)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(key) DO UPDATE SET
+              parent_sha=excluded.parent_sha,
+              depth=excluded.depth,
+              parent_token_count=excluded.parent_token_count,
+              token_count=excluded.token_count,
+              size_bytes=excluded.size_bytes,
+              last_used=excluded.last_used;
+            """)
+            defer { sqlite3_finalize(stmt) }
+            let now = Date().timeIntervalSince1970
+            sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+            if let p = parentSha {
+                sqlite3_bind_text(stmt, 2, p, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(stmt, 2)
+            }
+            sqlite3_bind_int(stmt, 3, Int32(depth))
+            sqlite3_bind_int64(stmt, 4, Int64(parentTokenCount))
+            sqlite3_bind_int64(stmt, 5, Int64(tokenCount))
+            sqlite3_bind_int64(stmt, 6, Int64(sizeBytes))
+            sqlite3_bind_double(stmt, 7, now)
+            if sqlite3_step(stmt) != SQLITE_DONE {
+                FileHandle.standardError.write(
+                    Data("[kvcache] register failed for \(key.prefix(12)): \(String(cString: sqlite3_errmsg(db)))\n".utf8))
+            }
+        }
+    }
+
+    /// Update last_used on a hit so LRU sorts correctly.
+    public func touch(key: String) {
+        serial.sync { touchInternal(key: key) }
+    }
+
+    /// Whether the metadata index knows this content-addressed chunk.
+    public func contains(key: String) -> Bool {
+        serial.sync {
+            let stmt = prepare("SELECT 1 FROM chunks WHERE key = ? LIMIT 1;")
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+            return sqlite3_step(stmt) == SQLITE_ROW
+        }
+    }
+
+    /// Possible variable-length children rooted at a known state boundary.
+    /// The caller validates content by deriving each key from prompt embeddings.
+    public func childEndpoints(
+        parentSha: String?, parentTokenCount: Int, before tokenCount: Int
+    ) -> [(key: String, tokenCount: Int)] {
+        serial.sync {
+            let parentClause = parentSha == nil ? "parent_sha IS NULL" : "parent_sha = ?"
+            let stmt = prepare("""
+            SELECT key, token_count FROM chunks
+            WHERE \(parentClause)
+              AND parent_token_count = ?
+              AND token_count > parent_token_count
+              AND token_count < ?
+            ORDER BY token_count DESC;
+            """)
+            defer { sqlite3_finalize(stmt) }
+            var bind: Int32 = 1
+            if let parentSha {
+                sqlite3_bind_text(stmt, bind, parentSha, -1, SQLITE_TRANSIENT)
+                bind += 1
+            }
+            sqlite3_bind_int64(stmt, bind, Int64(parentTokenCount))
+            sqlite3_bind_int64(stmt, bind + 1, Int64(tokenCount))
+            var result: [(String, Int)] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let key = sqlite3_column_text(stmt, 0) else { continue }
+                result.append((String(cString: key), Int(sqlite3_column_int64(stmt, 1))))
+            }
+            return result
+        }
+    }
+
+    private func touchInternal(key: String) {
+        let stmt = prepare("UPDATE chunks SET last_used = ? WHERE key = ?;")
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_double(stmt, 1, Date().timeIntervalSince1970)
+        sqlite3_bind_text(stmt, 2, key, -1, SQLITE_TRANSIENT)
+        sqlite3_step(stmt)
+    }
+
+    /// Total disk usage summed across rows. Includes the directory itself,
+    /// not the kvcache parent dir.
+    public func totalBytes() -> Int {
+        serial.sync {
+            let stmt = prepare("SELECT COALESCE(SUM(size_bytes), 0) FROM chunks;")
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+            return Int(sqlite3_column_int64(stmt, 0))
+        }
+    }
+
+    /// Evict leaves-first to free at least `bytesNeeded` bytes. Returns bytes
+    /// actually freed. Selection order is shortest-depth-first (shallow leaves
+    /// first), then least-recently-used within a depth. A parent with a live
+    /// child is protected: the "value" of a chunk = max(its own and all its
+    /// descendants' last_used), recomputed before selection so the leaf-only
+    /// pass never strands a subtree.
+    public func evictLeaves(bytesNeeded: Int, maxBytes: Int) -> Int {
+        serial.sync {
+            // Lift parent.last_used to max(children.last_used) for non-leaves.
+            // SQLite has no recursive CTE update that's cheap; instead, iterate
+            // depths from deepest to 0, recomputing each non-leaf as
+            // max(self.last_used, max(child.last_used)). Children whose parent
+            // has been evicted are reclassified as roots (parent_sha NULL).
+            let maxDepth = intScalar("SELECT COALESCE(MAX(depth), -1) FROM chunks;")
+            if maxDepth < 0 { return 0 }
+            for d in stride(from: maxDepth, through: 1, by: -1) {
+                let upd = prepare("""
+                UPDATE chunks
+                SET last_used = (
+                  SELECT MAX(c2.last_used)
+                  FROM chunks c2
+                  WHERE c2.parent_sha = chunks.key
+                )
+                WHERE depth = ?
+                  AND EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key);
+                """)
+                sqlite3_bind_int(upd, 1, Int32(d))
+                sqlite3_step(upd)
+                sqlite3_finalize(upd)
+            }
+
+            // Now pick chunks shortest-depth-first (a shallow leaf is more
+            // likely to be a stale root of a short, dead conversation than a
+            // deep chain still being extended), with LRU as the tie-breaker.
+            // Skip any chunk that still has children — by construction, a chunk
+            // with children has last_used >= its oldest descendant, but we
+            // only want to evict leaves here so we don't dangle trees.
+            var freed = 0
+            let stmt = prepare("""
+            SELECT key, size_bytes FROM chunks
+            WHERE NOT EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key)
+            ORDER BY depth ASC, last_used ASC;
+            """)
+            defer { sqlite3_finalize(stmt) }
+            var toDelete: [(String, Int)] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let keyC = sqlite3_column_text(stmt, 0)
+                let size = Int(sqlite3_column_int64(stmt, 1))
+                let key = keyC.map { String(cString: $0) } ?? ""
+                toDelete.append((key, size))
+            }
+            for (key, size) in toDelete {
+                if freed >= bytesNeeded && totalBytesScalar() <= maxBytes { break }
+                deleteChunk(key: key)
+                freed += size
+                FileHandle.standardError.write(
+                    Data("[kvcache] evicted \(key.prefix(12)) (\(size) bytes)\n".utf8))
+            }
+            return freed
+        }
+    }
+
+    private func deleteChunk(key: String) {
+        // Drop the DB row first (CASCADE orphans to parent_sha NULL). The
+        // directory is removed separately by the caller — we don't have
+        // access to the file system here, and the caller already needs to
+        // know the chunk path anyway.
+        let stmt = prepare("DELETE FROM chunks WHERE key = ?;")
+        sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+        sqlite3_step(stmt)
+        sqlite3_finalize(stmt)
+    }
+
+    public func remove(key: String) {
+        serial.sync { deleteChunk(key: key) }
+    }
+
+    /// Read parent_sha back (or nil for depth 0).
+    public func parentSha(key: String) -> String? {
+        serial.sync {
+            let stmt = prepare("SELECT parent_sha FROM chunks WHERE key = ? LIMIT 1;")
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+            guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+            guard let p = sqlite3_column_text(stmt, 0) else { return nil }
+            return String(cString: p)
+        }
+    }
+
+    // MARK: - low-level
+
+    private func prepare(_ sql: String) -> OpaquePointer? {
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) != SQLITE_OK {
+            FileHandle.standardError.write(
+                Data("[kvcache] prepare failed: \(String(cString: sqlite3_errmsg(db))) sql=\(sql)\n".utf8))
+            return nil
+        }
+        return stmt
+    }
+
+    private func intScalar(_ sql: String) -> Int {
+        let stmt = prepare(sql)
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return 0 }
+        return Int(sqlite3_column_int64(stmt, 0))
+    }
+
+    private func totalBytesScalar() -> Int { intScalar("SELECT COALESCE(SUM(size_bytes),0) FROM chunks;") }
+}
+
+// SQLite needs the SQLITE_TRANSIENT macro; Swift's SQLite3 module exposes
+// it as `unsafeBitCast(-1, to: sqlite3_destructor_type.self)` historically,
+// but the Swift module also defines `SQLITE_TRANSIENT` as a global.
+internal let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Sources/Slotstream/ChunkIndex.swift
+++ b/Sources/Slotstream/ChunkIndex.swift
@@ -19,13 +19,17 @@
 //   - parent_sha: parent's key (NULL for depth 0)
 //
 // Eviction: when total size exceeds the quota (--kv-cache-size, else env
-// SLOTSTREAM_KVCACHE_MAX_GB, default 20), the saver deletes a forest of
-// leaves (and orphans whose parent is gone) whose combined size clears the
-// deficit, choosing the lowest-value chunks first (where a chunk's value is
-// the max of its own and all its descendants' last_used, so leaves with live
-// children are protected). DiskCache.enforceQuota runs the same pass at
-// startup when the CLI flag lowers the quota; it also sweeps the evicted
-// chunks' directories off the disk.
+// SLOTSTREAM_KVCACHE_MAX_GB, default 20), the saver deletes leaves whose
+// combined size clears the deficit. Leaves are binned into four age
+// quartiles by last_used; the oldest bin goes first — all of it one tier,
+// ordered shallowest depth first, then LRU — and younger bins only if the
+// quota still demands it, so a freshly saved node is never the first thing
+// its own saver evicts. A parent with live children is protected: its value
+// is the max of its own and all its descendants' last_used. Passes repeat
+// until the quota holds, so a dead turn chain drains to its root.
+// DiskCache.enforceQuota runs the same policy at startup when the CLI flag
+// lowers the quota; it also sweeps the evicted chunks' directories off the
+// disk.
 //
 // Crashes mid-save leave a `.kv.partial` file in the chunk directory; the
 // next save for that key detects the partial and rewrites. The metadata DB
@@ -264,63 +268,104 @@ public final class ChunkIndex {
         }
     }
 
-    /// Evict leaves-first to free at least `bytesNeeded` bytes. Returns bytes
-    /// actually freed. Selection order is shortest-depth-first (shallow leaves
-    /// first), then least-recently-used within a depth. A parent with a live
-    /// child is protected: the "value" of a chunk = max(its own and all its
-    /// descendants' last_used), recomputed before selection so the leaf-only
-    /// pass never strands a subtree.
+    /// Evict leaves to free at least `bytesNeeded` bytes. Returns bytes
+    /// actually freed. Candidates are leaves only — a parent with a live
+    /// child is never dangled, and its value is the max of its own and all
+    /// its descendants' last_used, recomputed before selection. Leaves are
+    /// binned into four age quartiles by last_used: the oldest quartile goes
+    /// first, all of it one tier (within a tier, shallowest depth first, then
+    /// LRU), and younger tiers only if the quota still demands it. Recency
+    /// must dominate depth because a live conversation's tip is also its
+    /// shallowest leaf — depth-first ordering evicted the node the saver had
+    /// just written. Passes repeat until the quota holds, so a dead turn
+    /// chain drains to its root.
     public func evictLeaves(bytesNeeded: Int, maxBytes: Int) -> Int {
         serial.sync {
-            // Lift parent.last_used to max(children.last_used) for non-leaves.
-            // SQLite has no recursive CTE update that's cheap; instead, iterate
-            // depths from deepest to 0, recomputing each non-leaf as
-            // max(self.last_used, max(child.last_used)). Children whose parent
-            // has been evicted are reclassified as roots (parent_sha NULL).
-            let maxDepth = intScalar("SELECT COALESCE(MAX(depth), -1) FROM chunks;")
-            if maxDepth < 0 { return 0 }
-            for d in stride(from: maxDepth, through: 1, by: -1) {
-                let upd = prepare("""
-                UPDATE chunks
-                SET last_used = (
-                  SELECT MAX(c2.last_used)
-                  FROM chunks c2
-                  WHERE c2.parent_sha = chunks.key
-                )
-                WHERE depth = ?
-                  AND EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key);
-                """)
-                sqlite3_bind_int(upd, 1, Int32(d))
-                sqlite3_step(upd)
-                sqlite3_finalize(upd)
-            }
-
-            // Now pick chunks shortest-depth-first (a shallow leaf is more
-            // likely to be a stale root of a short, dead conversation than a
-            // deep chain still being extended), with LRU as the tie-breaker.
-            // Skip any chunk that still has children — by construction, a chunk
-            // with children has last_used >= its oldest descendant, but we
-            // only want to evict leaves here so we don't dangle trees.
             var freed = 0
-            let stmt = prepare("""
-            SELECT key, size_bytes FROM chunks
-            WHERE NOT EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key)
-            ORDER BY depth ASC, last_used ASC;
-            """)
-            defer { sqlite3_finalize(stmt) }
-            var toDelete: [(String, Int)] = []
-            while sqlite3_step(stmt) == SQLITE_ROW {
-                let keyC = sqlite3_column_text(stmt, 0)
-                let size = Int(sqlite3_column_int64(stmt, 1))
-                let key = keyC.map { String(cString: $0) } ?? ""
-                toDelete.append((key, size))
-            }
-            for (key, size) in toDelete {
-                if freed >= bytesNeeded && totalBytesScalar() <= maxBytes { break }
-                deleteChunk(key: key)
-                freed += size
-                FileHandle.standardError.write(
-                    Data("[kvcache] evicted \(key.prefix(12)) (\(size) bytes)\n".utf8))
+            // Turn-boundary chains (one node per prompt, one per decode) make
+            // dead conversations deep: a single pass can only see the current
+            // tips, and each eviction exposes the next ancestor as a leaf.
+            // Iterate lift/select/delete until the quota holds, nothing is a
+            // leaf any more, or a pass stops shrinking the index (a failed
+            // delete must not spin).
+            var lastTotal = Int.max
+            while true {
+                // Lift parent.last_used to max(children.last_used) for non-leaves.
+                // SQLite has no recursive CTE update that's cheap; instead, iterate
+                // depths from deepest to 0, recomputing each non-leaf as
+                // max(self.last_used, max(child.last_used)). Children whose parent
+                // has been evicted are reclassified as roots (parent_sha NULL).
+                let maxDepth = intScalar("SELECT COALESCE(MAX(depth), -1) FROM chunks;")
+                if maxDepth < 0 { return 0 }
+                for d in stride(from: maxDepth, through: 1, by: -1) {
+                    let upd = prepare("""
+                    UPDATE chunks
+                    SET last_used = (
+                      SELECT MAX(c2.last_used)
+                      FROM chunks c2
+                      WHERE c2.parent_sha = chunks.key
+                    )
+                    WHERE depth = ?
+                      AND EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key);
+                    """)
+                    sqlite3_bind_int(upd, 1, Int32(d))
+                    sqlite3_step(upd)
+                    sqlite3_finalize(upd)
+                }
+
+                // Select the current leaves — only chunks with no children
+                // are candidates, so a live parent is never dangled.
+                let stmt = prepare("""
+                SELECT key, size_bytes, depth, last_used FROM chunks
+                WHERE NOT EXISTS (SELECT 1 FROM chunks c2 WHERE c2.parent_sha = chunks.key);
+                """)
+                defer { sqlite3_finalize(stmt) }
+                var leaves: [(key: String, size: Int, depth: Int, lastUsed: Double)] = []
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    guard let keyC = sqlite3_column_text(stmt, 0) else { continue }
+                    leaves.append((
+                        String(cString: keyC),
+                        Int(sqlite3_column_int64(stmt, 1)),
+                        Int(sqlite3_column_int64(stmt, 2)),
+                        sqlite3_column_double(stmt, 3)))
+                }
+
+                // Age quartiles over the leaf frontier, oldest tier first:
+                // within a tier every age counts the same, and shallowest
+                // depth then LRU break the tie. A node saved seconds ago
+                // lands in the youngest tier and cannot go while an older
+                // tier still has a leaf — which is what stops the saver from
+                // evicting the node it just wrote.
+                let byAge = leaves.sorted { $0.lastUsed < $1.lastUsed }
+                var tiers:
+                    [[(key: String, size: Int, depth: Int, lastUsed: Double)]] =
+                    [[], [], [], []]
+                for (i, leaf) in byAge.enumerated() {
+                    tiers[min(3, 4 * i / max(byAge.count, 1))].append(leaf)
+                }
+                var progressed = false
+                tierLoop: for tier in tiers {
+                    for leaf in tier.sorted(by: {
+                        ($0.depth, $0.lastUsed) < ($1.depth, $1.lastUsed)
+                    }) {
+                        if freed >= bytesNeeded && totalBytesScalar() <= maxBytes {
+                            break tierLoop
+                        }
+                        deleteChunk(key: leaf.key)
+                        freed += leaf.size
+                        progressed = true
+                        FileHandle.standardError.write(
+                            Data("[kvcache] evicted \(leaf.key.prefix(12)) (\(leaf.size) bytes)\n".utf8))
+                    }
+                    if freed >= bytesNeeded && totalBytesScalar() <= maxBytes { break }
+                }
+                let total = totalBytesScalar()
+                if !progressed || total >= lastTotal
+                    || (freed >= bytesNeeded && total <= maxBytes)
+                {
+                    break
+                }
+                lastTotal = total
             }
             return freed
         }

--- a/Sources/Slotstream/Context.swift
+++ b/Sources/Slotstream/Context.swift
@@ -20,6 +20,7 @@ public enum ContextPolicy {
 
     /// nil when `tokens` is an acceptable --max-context, otherwise the reason.
     public static func validationError(_ tokens: Int) -> String? {
+        return nil;
         if tokens >= 1, tokens <= maxTokens { return nil }
         return "--max-context must be between 1 and \(maxTokens): that ceiling is the "
             + "largest context slotstream has measured on this hardware, not a memory limit "

--- a/Sources/Slotstream/DiskCache.swift
+++ b/Sources/Slotstream/DiskCache.swift
@@ -1,0 +1,792 @@
+// Disk-persisted chunk KV cache: saves prefix states after each prefill chunk
+// plus the variable-length endpoint after decode, and reloads them to skip
+// recomputation. Layout:
+//   ~/.slotstream/kvcache/
+//     metadata.db                 SQLite index (parent chains, last_used, sizes)
+//     <key>/
+//       data.kv                   chunk delta + endpoint recurrent state
+//                                 (one .kv.partial is
+//                                 rewritten atomically; final name is data.kv)
+//       parent_sha.bin            parent chunk's key as hex UTF-8, empty at depth 0
+//       emb_sha.bin               embedding sha256 as hex UTF-8
+// Key derivation lives in ChunkIndex.makeKey and binds chunks to their
+// ancestors: sha256(parent_sha || sha256(chunk_embeddings)). Two conversations
+// that share the first 4096 tokens but diverge at position 4097 get two
+// distinct keys at depth 1, so a content match can never produce a wrong
+// KVCache (the linear-attention / MTP recurrent states can't be rewound).
+
+import Foundation
+import CryptoKit
+import MLX
+
+public enum DiskCache {
+    /// The disk tier is OFF unless someone asks for it: the CLI flags
+    /// (--disk-kv-cache / --disk-kv-cache-size), the env vars
+    /// (SLOTSTREAM_KVCACHE_DIR / SLOTSTREAM_KVCACHE_MAX_GB /
+    /// SLOTSTREAM_KVCACHE_ENABLE=1), and only
+    /// after an explicit opt-in. Default-off keeps every offline gate hermetic
+    /// — a check's first process must see a cold prompt even if a later
+    /// process will reuse it, and earlier saves by a previous process must
+    /// never turn a "cold" baseline warm. SLOTSTREAM_KVCACHE_DISABLE=1 wins
+    /// over everything.
+    static var enabled: Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["SLOTSTREAM_KVCACHE_DISABLE"] == "1" { return false }
+        if env["SLOTSTREAM_KVCACHE_ENABLE"] == "1" { return true }
+        if dirOverride != nil || maxBytesOverride != nil { return true }
+        if env["SLOTSTREAM_KVCACHE_DIR"] != nil || env["SLOTSTREAM_KVCACHE_MAX_GB"] != nil {
+            return true
+        }
+        return false
+    }
+    /// Explicit process-global override. Set by the CLI's --disk-kv-cache;
+    /// takes precedence over the env var so a single command-line invocation
+    /// is hermetic. Reads from `DiskCache.dir` everywhere, so it just has
+    /// to be set before any chunk is touched.
+    public static var dirOverride: String?
+    /// Explicit process-global quota override, in GB. Set by the CLI's
+    /// --kv-cache-size; takes precedence over SLOTSTREAM_KVCACHE_MAX_GB so a
+    /// single invocation is hermetic. Must be set before the first save or
+    /// enforcement (the CLI applies it in announcedPlan, before the model).
+    public static var maxBytesOverride: Double?
+    static var dir: URL {
+        if let o = dirOverride, !o.isEmpty {
+            return URL(fileURLWithPath: o)
+        }
+        if let s = ProcessInfo.processInfo.environment["SLOTSTREAM_KVCACHE_DIR"], !s.isEmpty {
+            return URL(fileURLWithPath: s)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".slotstream/kvcache", isDirectory: true)
+    }
+    /// On-disk quota. Old entries beyond this are evicted leaf-first.
+    static var maxBytes: Int {
+        let gb = maxBytesOverride
+            ?? ProcessInfo.processInfo.environment["SLOTSTREAM_KVCACHE_MAX_GB"]
+                .flatMap { Double($0) }
+            ?? 20.0
+        return Int(gb * 1_073_741_824.0)
+    }
+
+    /// Force the on-disk cache under its quota with the existing eviction
+    /// policy (`ChunkIndex.evictLeaves`): least recently valuable subtrees
+    /// first, leaves only, so a parent with live children is protected.
+    /// No-op while under quota. Returns bytes freed. Runs at startup when
+    /// --kv-cache-size is given, and after every save.
+    @discardableResult
+    public static func enforceQuota() -> Int {
+        let max = maxBytes
+        let total = ChunkIndex.shared.totalBytes()
+        guard total > max else { return 0 }
+        let freed = ChunkIndex.shared.evictLeaves(bytesNeeded: total - max, maxBytes: max)
+        if freed > 0 {
+            sweepOrphans()
+            log("evicted \(freed) bytes, now \(ChunkIndex.shared.totalBytes()) bytes on disk")
+        }
+        return freed
+    }
+
+    /// Serial queue so chunk saves during one prefill (4096, 8192, 12288...)
+    /// write one at a time instead of three ~1 GB flushes racing each other
+    /// and the running prefill for memory and disk bandwidth.
+    static let saveQueue = DispatchQueue(label: "slotstream.kvcache.save", qos: .utility)
+
+    /// Bytes the cache volume can still take (important-usage capacity), for
+    /// the disk-full guard. Best-effort: nil when the volume is unreadable.
+    private static func volumeFreeBytes(at url: URL) -> Int? {
+        (try? url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]))
+            .flatMap { $0.volumeAvailableCapacityForImportantUsage }
+            .flatMap { Int(exactly: $0) }
+    }
+
+    /// Upper-bound estimate of the serialized payload for one save. Overstates
+    /// wherever a checkpoint holds a grown-but-partially-used buffer (the KV
+    /// capacity beyond the snapshot); overstating is the safe direction for a
+    /// disk-headroom guard.
+    private static func estimatedContentBytes(_ cp: StateCheckpoint) -> Int {
+        var total = 0
+        func add(_ a: MLXArray?) {
+            guard let a = a else { return }
+            let n = a.shape.reduce(1) { $0 * max(1, $1) }
+            total += n * 4
+        }
+        for a in cp.conv.values { add(a) }
+        for a in cp.ssm.values { add(a) }
+        for a in cp.pleConv.values { add(a) }
+        for (k, v) in cp.kv.values { add(k); add(v) }
+        for a in cp.indexer.values { add(a) }
+        if let lm = cp.lastMulti { add(lm) }
+        if let (k, v) = cp.mtpKV { add(k); add(v) }
+        if let b = cp.mtpIndexer { add(b) }
+        return total
+    }
+
+    /// Drop enough leaves to free `bytesNeeded` physical bytes: the leaf-first
+    /// policy, plus sweeping the directories off the disk (evictLeaves removes
+    /// index rows only). Never touches non-leaf chunks. A full volume must
+    /// degrade to dropping the oldest chunks rather than fail a save.
+    private static func evictForFreeSpace(_ bytesNeeded: Int) -> Int {
+        guard bytesNeeded > 0 else { return 0 }
+        let freed = ChunkIndex.shared.evictLeaves(bytesNeeded: bytesNeeded, maxBytes: Int.max)
+        if freed > 0 { sweepOrphans() }
+        return freed
+    }
+
+    /// Block until every queued save has finished. Safe to call from the
+    /// main thread; never call from inside a save callback.
+    public static func flush() {
+        saveQueue.sync { }
+    }
+
+    static func log(_ s: String) {
+        FileHandle.standardError.write(Data("[kvcache] \(s)\n".utf8))
+    }
+
+    // MARK: - key derivation (delegates to ChunkIndex; per-chunk hashes)
+
+    /// Compute sha256 of a row-major embedding slice. Side-file only; the
+    /// key itself is derived in ChunkIndex.makeKey so lookups and saves can
+    /// never disagree about what identifies a chunk.
+    static func embeddingSha(embeddings: [Float]) -> String {
+        var hasher = SHA256()
+        var buf = Data(capacity: embeddings.count * 4)
+        for v in embeddings {
+            var f = v.bitPattern.littleEndian
+            withUnsafeBytes(of: &f) { buf.append(contentsOf: $0) }
+        }
+        hasher.update(data: buf)
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - save
+
+    /// Save the node that ends at `tokens`. Prefill nodes normally end on the
+    /// configured chunk boundary; post-decode terminal nodes need not. The
+    /// key is computed synchronously by the caller so the next chunk's
+    /// parent_sha can be derived without waiting for the IO. The actual
+    /// write runs on the serial save queue; if the same key is queued twice
+    /// (e.g. two requests racing on the same prefix), the second one no-ops.
+    /// `parentSha` is the previous chunk's key, or nil for depth 0.
+    public static func saveAsync(
+        state: Qwen4ExpModel.State,
+        tokenIds: [Int],
+        key: String,
+        parentSha: String?,
+        depth: Int,
+        embeddings: [Float],
+        parentTokenCount: Int
+    ) {
+        guard enabled else { return }
+        let embSha = embeddingSha(embeddings: embeddings)
+        let base = dir.appendingPathComponent(key, isDirectory: true)
+        let cp = state.checkpoint()
+        let tokenCount = tokenIds.count
+        guard parentTokenCount >= 0, parentTokenCount < tokenCount,
+              cp.tokenCount == tokenCount
+        else {
+            log("SAVE FAILED for \(tokenCount) tokens depth=\(depth): invalid parent/token boundary")
+            return
+        }
+        log("save queued: \(tokenIds.count) tokens depth=\(depth) key=\(key.prefix(12))")
+        let t0 = Date()
+        saveQueue.async {
+            // The actual write. `needsSpaceRetry` lets a disk-full failure
+            // evict the least-valuable leaves and try once more before giving
+            // up — a save must degrade to dropping chunks, never crash on a
+            // full volume.
+            var needsSpaceRetry = true
+            func performSave() throws {
+                do {
+                    // Already complete: skip. The check happens after queue
+                    // dispatch so concurrent saves of the same key serialize.
+                    let dataPath = base.appendingPathComponent("data.kv")
+                    if cacheFileVersion(at: dataPath) == 4 {
+                        let wasIndexed = ChunkIndex.shared.contains(key: key)
+                        if wasIndexed {
+                            ChunkIndex.shared.touch(key: key)
+                        } else {
+                            ChunkIndex.shared.register(
+                                key: key, parentSha: parentSha, depth: depth,
+                                parentTokenCount: parentTokenCount, tokenCount: tokenCount,
+                                sizeBytes: directorySize(at: base))
+                        }
+                        let reconciliation = wasIndexed ? "" : "; restored missing index row"
+                        log("save skipped: \(tokenIds.count) tokens depth=\(depth) key=\(key.prefix(12)) already complete on disk\(reconciliation)")
+                        return
+                    }
+                    if FileManager.default.fileExists(atPath: dataPath.path) {
+                        ChunkIndex.shared.remove(key: key)
+                        log("save replacing: depth=\(depth) key=\(key.prefix(12)) old or malformed cache format")
+                    }
+                    // The write needs a real place to land. The checkpoint
+                    // payload is the bulk; if the volume cannot take it, drop
+                    // the least-valuable leaves first. On a physically full
+                    // disk the post-write quota eviction won't run (the write
+                    // fails first), so this guard is the only chance to make
+                    // room.
+                    if let free = volumeFreeBytes(at: base),
+                       free < estimatedContentBytes(cp) {
+                        let needed = estimatedContentBytes(cp) - free
+                        let freed = evictForFreeSpace(needed)
+                        log("save evicted \(freed) bytes to free disk space for \(tokenCount) tokens depth=\(depth)")
+                    }
+                    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+                    let partialPath = base.appendingPathComponent("data.kv.partial")
+                    let parentPath = base.appendingPathComponent("parent_sha.bin")
+                    let embPath = base.appendingPathComponent("emb_sha.bin")
+
+                    // Crash-safe write: write to .partial, rename to data.kv on
+                    // completion. POSIX rename on the same FS is atomic, so a
+                    // crash mid-write leaves either the old data.kv or the
+                    // .partial — never a half-written data.kv.
+                    if FileManager.default.fileExists(atPath: partialPath.path) {
+                        try? FileManager.default.removeItem(at: partialPath)
+                    }
+                    let fm = FileManager.default
+                    fm.createFile(atPath: partialPath.path, contents: nil)
+                    let outHandle = try FileHandle(forWritingTo: partialPath)
+
+                    // Header line is one small JSON with the offsets the loader
+                    // needs to restore the state without reading every .bin
+                    // separately. Array blobs follow in a length-prefixed
+                    // <shape,json,bytes> format identical to the old layout.
+                    let meta: [String: Any] = [
+                        "tokenCount": cp.tokenCount,
+                        "parentTokenCount": parentTokenCount,
+                        "ngramCtx": cp.ngramCtx,
+                        "linearLayers": cp.linearLayers,
+                        "pleLayers": cp.pleConv.keys.sorted(),
+                        "kvLayers": cp.kvOffsets.keys.sorted(),
+                        "indexerLayers": cp.indexerOffsets.keys.sorted(),
+                        "mtpPresent": cp.mtpKV != nil,
+                        "mtpStart": max(0, parentTokenCount - 1),
+                        "mtpEnd": cp.mtpOffset,
+                        "version": 4
+                    ]
+                    let metaData = try JSONSerialization.data(withJSONObject: meta, options: [])
+                    try outHandle.write(contentsOf: metaData)
+                    try outHandle.write(contentsOf: Data("\n".utf8))
+
+                    func writeArray(_ arr: MLXArray?, name: String) throws {
+                        guard let a = arr else { return }
+                        let f32 = a.asType(.float32)
+                        let shape = f32.shape
+                        let arrData = f32.asArray(Float.self)
+                        // liveDtype records what the running model held: the
+                        // GDN SSM state is float32 by design (bf16 loses
+                        // precision across the recurrence), everything else is
+                        // bfloat16. Restoring ssm to bf16 corrupts it.
+                        let live: String
+                        switch a.dtype {
+                        case .float32: live = "float32"
+                        case .float16: live = "float16"
+                        default: live = "bfloat16"
+                        }
+                        let header: [String: Any] = [
+                            "name": name, "shape": shape, "dtype": "float32", "liveDtype": live]
+                        let headerData = try JSONSerialization.data(withJSONObject: header, options: [])
+                        var len = UInt32(headerData.count).littleEndian
+                        var combined = Data()
+                        withUnsafeBytes(of: &len) { combined.append(contentsOf: $0) }
+                        combined.append(headerData)
+                        arrData.withUnsafeBytes { combined.append(contentsOf: $0) }
+                        try outHandle.write(contentsOf: combined)
+                    }
+
+                    for (l, arr) in cp.conv { try writeArray(arr, name: "conv_\(l)") }
+                    for (l, arr) in cp.ssm { try writeArray(arr, name: "ssm_\(l)") }
+                    for (l, arr) in cp.pleConv { try writeArray(arr, name: "pleConv_\(l)") }
+                    if let lm = cp.lastMulti { try writeArray(lm, name: "lastMulti") }
+                    let delta = parentTokenCount ..< tokenCount
+                    for (l, off) in cp.kvOffsets {
+                        guard off == tokenCount, let pair = cp.kv[l],
+                              pair.keys.dim(2) >= tokenCount,
+                              pair.values.dim(2) >= tokenCount
+                        else { throw ModelError("incomplete KV snapshot for layer \(l)") }
+                        try writeArray(
+                            pair.keys[0..., 0..., delta, 0...], name: "kv_k_\(l)")
+                        try writeArray(
+                            pair.values[0..., 0..., delta, 0...], name: "kv_v_\(l)")
+                    }
+                    for (l, off) in cp.indexerOffsets {
+                        guard off == tokenCount, let b = cp.indexer[l], b.dim(1) >= tokenCount
+                        else { throw ModelError("incomplete indexer snapshot for layer \(l)") }
+                        try writeArray(b[0..., delta, 0...], name: "indexer_\(l)")
+                    }
+                    if let (k, v) = cp.mtpKV {
+                        let mtpStart = max(0, parentTokenCount - 1)
+                        guard cp.mtpOffset == max(0, tokenCount - 1),
+                              k.dim(2) >= cp.mtpOffset, v.dim(2) >= cp.mtpOffset,
+                              let b = cp.mtpIndexer, b.dim(1) >= cp.mtpOffset
+                        else { throw ModelError("incomplete MTP snapshot") }
+                        let mtpDelta = mtpStart ..< cp.mtpOffset
+                        try writeArray(k[0..., 0..., mtpDelta, 0...], name: "mtp_kv_k")
+                        try writeArray(v[0..., 0..., mtpDelta, 0...], name: "mtp_kv_v")
+                        try writeArray(b[0..., mtpDelta, 0...], name: "mtp_indexer")
+                    } else if cp.mtpOffset != 0 {
+                        throw ModelError("MTP offset has no cache arrays")
+                    }
+
+                    try outHandle.close()
+
+                    // Atomic publish.
+                    if fm.fileExists(atPath: dataPath.path) { try fm.removeItem(at: dataPath) }
+                    try fm.moveItem(at: partialPath, to: dataPath)
+
+                    // parent_sha and emb_sha are 32-byte binary, hex-encoded for
+                    // cheap concatenation in makeKey.
+                    let parentBytes = parentSha?.data(using: .utf8) ?? Data()
+                    try parentBytes.write(to: parentPath)
+                    try Data(embSha.utf8).write(to: embPath)
+
+                    // Register in the index only after the file is published and
+                    // committed. A crash before this point leaves no row, which
+                    // is harmless: the next lookup won't find the chunk and will
+                    // rebuild.
+                    let dirSize = directorySize(at: base)
+                    ChunkIndex.shared.register(
+                        key: key, parentSha: parentSha, depth: depth,
+                        parentTokenCount: parentTokenCount, tokenCount: tokenCount,
+                        sizeBytes: dirSize)
+
+                    // Eviction: if over quota, drop leaves until under quota.
+                    enforceQuota()
+
+                    log("save done: \(tokenIds.count) tokens depth=\(depth) key=\(key.prefix(12)) "
+                        + "\(String(format: "%.1f", Double(dirSize) / 1e6)) MB in "
+                        + String(format: "%.1fs", -t0.timeIntervalSinceNow))
+                } catch {
+                    // The payload could not be written. On the first failure,
+                    // free space by evicting and try exactly once more — the
+                    // two most common causes (a full volume, or a stale view
+                    // of how full it is) both clear themselves. A genuine
+                    // corruption error will fail the retry too and surface.
+                    if needsSpaceRetry {
+                        needsSpaceRetry = false
+                        _ = evictForFreeSpace(estimatedContentBytes(cp))
+                        try performSave()
+                    } else {
+                        throw error
+                    }
+                }
+            }
+            do {
+                try performSave()
+            } catch {
+                log("SAVE FAILED for \(tokenIds.count) tokens depth=\(depth): \(error)")
+                try? FileManager.default.removeItem(
+                    at: base.appendingPathComponent("data.kv.partial"))
+            }
+        }
+    }
+
+    // MARK: - lookup
+
+    /// Walk the chain depth-by-depth. For each depth i, the caller supplies
+    /// the embeddings of the chunk at `[i*chunk, (i+1)*chunk)` via `embed`.
+    /// We compute the per-chunk key and stop at the first miss. Returns the
+    /// longest prefix length whose chain is fully present, or nil.
+    public static func longestPrefixHit(
+        chunk: Int,
+        embed: (Int) -> [Float]?
+    ) -> Int? {
+        guard enabled, chunk > 0 else { return nil }
+        var parentSha: String? = nil
+        var depth = 0
+        while let embeddings = embed(depth) {
+            let key = ChunkIndex.makeKey(parentSha: parentSha, embeddings: embeddings)
+            let base = dir.appendingPathComponent(key, isDirectory: true)
+            let dataPath = base.appendingPathComponent("data.kv")
+            let isIndexed = ChunkIndex.shared.contains(key: key)
+            let isOnDisk = FileManager.default.fileExists(atPath: dataPath.path)
+            if isOnDisk, cacheFileVersion(at: dataPath) != 4 {
+                if isIndexed { ChunkIndex.shared.remove(key: key) }
+                log("chain break: depth=\(depth + 1) key=\(key.prefix(12)) old or malformed cache format; rebuild required")
+                break
+            }
+            if isIndexed && isOnDisk {
+                ChunkIndex.shared.touch(key: key)
+                parentSha = key
+                depth += 1
+                continue
+            }
+
+            if isIndexed {
+                ChunkIndex.shared.remove(key: key)
+                log("chain break: depth=\(depth + 1) key=\(key.prefix(12)) indexed but data.kv is missing; removed stale index row")
+                break
+            }
+
+            if isOnDisk {
+                // A crash can publish data.kv and die before registering it.
+                // The save path also regards this atomic file as complete, so
+                // make lookup use the same source of truth and heal the index.
+                ChunkIndex.shared.register(
+                    key: key, parentSha: parentSha, depth: depth + 1,
+                    parentTokenCount: depth * chunk, tokenCount: (depth + 1) * chunk,
+                    sizeBytes: directorySize(at: base))
+                log("lookup recovered: depth=\(depth + 1) key=\(key.prefix(12)) data.kv existed but index row was missing")
+                parentSha = key
+                depth += 1
+                continue
+            }
+
+            let partialPath = base.appendingPathComponent("data.kv.partial")
+            if FileManager.default.fileExists(atPath: partialPath.path) {
+                log("chain break: depth=\(depth + 1) key=\(key.prefix(12)) index row missing; only data.kv.partial exists")
+            } else if FileManager.default.fileExists(atPath: base.path) {
+                log("chain break: depth=\(depth + 1) key=\(key.prefix(12)) index row and data.kv missing; key directory exists")
+            } else {
+                log("chain break: depth=\(depth + 1) key=\(key.prefix(12)) absent from index and disk")
+            }
+            break
+        }
+        return depth == 0 ? nil : depth * chunk
+    }
+
+    // MARK: - load
+
+    /// Rebuild a state by applying `depth` fixed-size nodes and, when present,
+    /// one variable-length terminal child.
+    public static func loadState(
+        for embed: (Int) -> [Float]?,
+        depth: Int,
+        terminalKey: String? = nil,
+        tokenIds: [Int],
+        template: Qwen4ExpModel.State
+    ) -> Qwen4ExpModel.State? {
+        guard enabled else {
+            log("load skipped: disk cache disabled")
+            return nil
+        }
+        guard depth > 0 || terminalKey != nil else {
+            log("load failed: invalid chain depth \(depth)")
+            return nil
+        }
+        var keys: [String] = []
+        var parentSha: String? = nil
+        for i in 0..<depth {
+            guard let e = embed(i) else {
+                log("load failed: embeddings unavailable at depth=\(i + 1)")
+                return nil
+            }
+            let key = ChunkIndex.makeKey(parentSha: parentSha, embeddings: e)
+            keys.append(key)
+            parentSha = key
+        }
+        if let terminalKey { keys.append(terminalKey) }
+
+        let state = template
+        for (index, key) in keys.enumerated() {
+            guard applyNode(key: key, depth: index + 1, to: state) else { return nil }
+        }
+        guard state.tokenCount == tokenIds.count else {
+            log("load failed: chain restored \(state.tokenCount) tokens, expected \(tokenIds.count)")
+            return nil
+        }
+        log("load done: \(tokenIds.count) tokens depth=\(depth) key=\(keys.last!.prefix(12)) from \(keys.count) nodes")
+        return state
+    }
+
+    private static func applyNode(
+        key: String, depth: Int, to state: Qwen4ExpModel.State
+    ) -> Bool {
+        let base = dir.appendingPathComponent(key, isDirectory: true)
+        let dataPath = base.appendingPathComponent("data.kv")
+        var accepted = false
+        defer {
+            if !accepted {
+                ChunkIndex.shared.remove(key: key)
+                try? FileManager.default.removeItem(at: dataPath)
+                log("load invalidated: depth=\(depth) key=\(key.prefix(12)) will be rebuilt")
+            }
+        }
+        guard FileManager.default.fileExists(atPath: dataPath.path) else {
+            ChunkIndex.shared.remove(key: key)
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) indexed but data.kv is missing; removed stale index row")
+            return false
+        }
+        guard let data = try? Data(contentsOf: dataPath) else {
+            log("load: data.kv unreadable for key=\(key.prefix(12))")
+            return false
+        }
+        guard let nlIndex = data.firstIndex(of: 0x0a) else {
+            log("load: no header newline in data.kv for key=\(key.prefix(12)) (size \(data.count))")
+            return false
+        }
+        let metaData = data[0..<nlIndex]
+        guard let meta = try? JSONSerialization.jsonObject(with: metaData) as? [String: Any]
+        else {
+            log("load: bad meta header JSON for key=\(key.prefix(12))")
+            return false
+        }
+        if (meta["version"] as? Int) != 4 {
+            log("load: bad version \(meta["version"] ?? -1) for key=\(key.prefix(12))")
+            return false
+        }
+        var body = data.subdata(in: (nlIndex + 1)..<data.count)
+
+        // Read the body one array at a time. `body` is re-based to index 0
+        // so the offsets below are correct. Each array on disk is
+        // `<len:u32-le><header:len bytes of JSON><floats:shape-product*4 bytes>`,
+        // and the float byte count is derived from the parsed shape so we
+        // never consume into the next array's header.
+        var arraysByName: [String: MLXArray] = [:]
+        var bodyFailure: String? = nil
+        while body.count >= 4 {
+            let len = body[0..<4]
+                .withUnsafeBytes { $0.load(as: UInt32.self).littleEndian }
+            let headerSize = 4 + Int(len)
+            guard body.count >= headerSize else {
+                bodyFailure = "truncated array header"
+                break
+            }
+            let headerData = body[4..<headerSize]
+            guard let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any],
+                  let name = header["name"] as? String,
+                  let shape = header["shape"] as? [Int]
+            else {
+                bodyFailure = "invalid array header JSON"
+                break
+            }
+            var elementCount = 1
+            var shapeIsValid = true
+            for dim in shape {
+                guard dim >= 0 else {
+                    shapeIsValid = false
+                    break
+                }
+                let (next, overflow) = elementCount.multipliedReportingOverflow(by: dim)
+                guard !overflow else {
+                    shapeIsValid = false
+                    break
+                }
+                elementCount = next
+            }
+            let (dataBytes, byteOverflow) = elementCount.multipliedReportingOverflow(by: 4)
+            guard shapeIsValid, !byteOverflow else {
+                bodyFailure = "invalid or overflowing shape for \(name)"
+                break
+            }
+            guard dataBytes <= body.count - headerSize else {
+                bodyFailure = "truncated array data for \(name)"
+                break
+            }
+            let raw = body[headerSize..<(headerSize + dataBytes)]
+            body = body.subdata(in: (headerSize + dataBytes)..<body.count)
+            let floats = raw.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+            // Restore to the dtype the live model held (liveDtype, added in
+            // v3 headers): the SSM state must come back as float32 or the
+            // recurrence diverges. Older headers without the field restore
+            // as bfloat16, which only the bf16 arrays did hold.
+            let dt: DType
+            switch header["liveDtype"] as? String {
+            case "float32": dt = .float32
+            case "float16": dt = .float16
+            default: dt = .bfloat16
+            }
+            arraysByName[name] = MLXArray(floats, shape).asType(dt)
+        }
+        if bodyFailure == nil, !body.isEmpty {
+            bodyFailure = "trailing \(body.count) bytes"
+        }
+        if let failure = bodyFailure {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) \(failure)")
+            return false
+        }
+
+        guard let tokenCount = meta["tokenCount"] as? Int,
+              let parentTokenCount = meta["parentTokenCount"] as? Int,
+              parentTokenCount == state.tokenCount,
+              tokenCount > parentTokenCount
+        else {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) non-contiguous token boundary")
+            return false
+        }
+        let deltaCount = tokenCount - parentTokenCount
+        guard let linearLayers = meta["linearLayers"] as? [Int],
+              Set(linearLayers) == Set(state.linear.keys),
+              let kvLayers = meta["kvLayers"] as? [Int],
+              Set(kvLayers) == Set(state.kv.keys),
+              let indexerLayers = meta["indexerLayers"] as? [Int],
+              Set(indexerLayers) == Set(state.indexer.keys),
+              let pleLayers = meta["pleLayers"] as? [Int],
+              Set(pleLayers) == state.expectedPLELayers
+        else {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) cache layer set mismatch")
+            return false
+        }
+
+        for l in linearLayers {
+            guard let conv = arraysByName["conv_\(l)"],
+                  let ssm = arraysByName["ssm_\(l)"],
+                  conv.shape == state.expectedConvShape, conv.dtype == .bfloat16,
+                  ssm.shape == state.expectedSSMShape, ssm.dtype == .float32
+            else {
+                log("load failed: depth=\(depth) key=\(key.prefix(12)) bad recurrent arrays for layer \(l)")
+                return false
+            }
+        }
+        for l in pleLayers {
+            guard let ple = arraysByName["pleConv_\(l)"],
+                  ple.shape == state.expectedPLEShape, ple.dtype == .bfloat16
+            else {
+                log("load failed: depth=\(depth) key=\(key.prefix(12)) bad PLE array for layer \(l)")
+                return false
+            }
+        }
+        for l in kvLayers {
+            guard let k = arraysByName["kv_k_\(l)"],
+                  let v = arraysByName["kv_v_\(l)"],
+                  k.ndim == 4, v.ndim == 4,
+                  k.shape == [1, state.expectedKVHeads, deltaCount, state.expectedKVHeadDim],
+                  v.shape == k.shape, k.dtype == .bfloat16, v.dtype == .bfloat16
+            else {
+                log("load failed: depth=\(depth) key=\(key.prefix(12)) bad KV delta for layer \(l)")
+                return false
+            }
+        }
+        for l in indexerLayers {
+            guard let b = arraysByName["indexer_\(l)"],
+                  b.shape == [1, deltaCount, state.expectedIndexerDim],
+                  b.dtype == .bfloat16
+            else {
+                log("load failed: depth=\(depth) key=\(key.prefix(12)) bad indexer delta for layer \(l)")
+                return false
+            }
+        }
+
+        let mtpPresent = meta["mtpPresent"] as? Bool ?? false
+        let mtpStart = meta["mtpStart"] as? Int ?? 0
+        let mtpEnd = meta["mtpEnd"] as? Int ?? 0
+        if mtpPresent {
+            guard mtpStart == (state.mtp?.offset ?? 0), mtpEnd >= mtpStart,
+                  let k = arraysByName["mtp_kv_k"],
+                  let v = arraysByName["mtp_kv_v"],
+                  let b = arraysByName["mtp_indexer"],
+                  k.ndim == 4, v.ndim == 4, b.ndim == 3,
+                  k.shape == [1, state.expectedKVHeads,
+                              mtpEnd - mtpStart, state.expectedKVHeadDim],
+                  v.shape == k.shape,
+                  b.shape == [1, mtpEnd - mtpStart, state.expectedIndexerDim],
+                  k.dtype == .bfloat16, v.dtype == .bfloat16,
+                  b.dtype == .bfloat16,
+                  arraysByName["lastMulti"] != nil
+            else {
+                log("load failed: depth=\(depth) key=\(key.prefix(12)) invalid MTP delta")
+                return false
+            }
+        } else if state.mtp != nil
+            || arraysByName["mtp_kv_k"] != nil
+            || arraysByName["mtp_kv_v"] != nil
+            || arraysByName["mtp_indexer"] != nil
+        {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) mixed MTP chain")
+            return false
+        }
+
+        for l in linearLayers {
+            state.linear[l]?.convState = arraysByName["conv_\(l)"]
+            state.linear[l]?.ssmState = arraysByName["ssm_\(l)"]
+            state.linear[l]?.pleConvState = arraysByName["pleConv_\(l)"]
+        }
+        for l in kvLayers {
+            guard state.kv[l]!.append(
+                keys: arraysByName["kv_k_\(l)"]!,
+                values: arraysByName["kv_v_\(l)"]!)
+            else { return false }
+        }
+        for l in indexerLayers {
+            guard state.indexer[l]!.append(arraysByName["indexer_\(l)"]!) else { return false }
+        }
+        if mtpPresent {
+            if state.mtp == nil { state.mtp = MTPState() }
+            guard state.mtp!.kv.append(
+                keys: arraysByName["mtp_kv_k"]!, values: arraysByName["mtp_kv_v"]!),
+                  state.mtp!.indexer.append(arraysByName["mtp_indexer"]!),
+                  state.mtp!.offset == mtpEnd
+            else { return false }
+        }
+        let ngram: [Int64]
+        if let saved = meta["ngramCtx"] as? [Int64] { ngram = saved }
+        else if let saved = meta["ngramCtx"] as? [Int] { ngram = saved.map { Int64($0) } }
+        else {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) ngram context missing")
+            return false
+        }
+        guard ngram.count == state.ngramCtx.count else {
+            log("load failed: depth=\(depth) key=\(key.prefix(12)) bad ngram context")
+            return false
+        }
+        state.ngramCtx = ngram
+        state.tokenCount = tokenCount
+        state.lastMulti = arraysByName["lastMulti"]
+
+        var materialize = Array(arraysByName.values)
+        for cache in state.kv.values {
+            if let k = cache.keys { materialize.append(k) }
+            if let v = cache.values { materialize.append(v) }
+        }
+        for cache in state.indexer.values {
+            if let b = cache.snapshot() { materialize.append(b) }
+        }
+        if let mtp = state.mtp {
+            if let k = mtp.kv.keys { materialize.append(k) }
+            if let v = mtp.kv.values { materialize.append(v) }
+            if let b = mtp.indexer.snapshot() { materialize.append(b) }
+        }
+        eval(materialize)
+        ChunkIndex.shared.touch(key: key)
+        accepted = true
+        return true
+    }
+
+    // MARK: - utilities
+
+    private static func cacheFileVersion(at url: URL) -> Int? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: 4096),
+              let nlIndex = data.firstIndex(of: 0x0a),
+              let meta = try? JSONSerialization.jsonObject(
+                with: data[0..<nlIndex]) as? [String: Any]
+        else { return nil }
+        return meta["version"] as? Int
+    }
+
+    private static func directorySize(at url: URL) -> Int {
+        let fm = FileManager.default
+        guard let it = fm.enumerator(
+            at: url, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey])
+        else { return 0 }
+        var total = 0
+        for case let f as URL in it {
+            let vals = try? f.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if vals?.isRegularFile == true { total += vals?.fileSize ?? 0 }
+        }
+        return total
+    }
+
+    /// Remove chunk directories whose key is no longer in the index — the
+    /// leaves evictLeaves dropped (it deletes DB rows only; this is where the
+    /// directory actually leaves the disk) — and directories that can never
+    /// load (no data.kv: crash leftovers, legacy layouts). Called after
+    /// eviction so a stale process can't be tripped up by the disk outlasting
+    /// the DB. This also bounds the lookup-heal window: an unindexed data.kv
+    /// would otherwise be re-registered by longestPrefixHit and resurrect a
+    /// chunk the eviction deliberately chose to drop.
+    private static func sweepOrphans() {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.isDirectoryKey]) else { return }
+        for entry in entries {
+            guard (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            else { continue }
+            let dataPath = entry.appendingPathComponent("data.kv")
+            if !ChunkIndex.shared.contains(key: entry.lastPathComponent)
+                || !fm.fileExists(atPath: dataPath.path) {
+                try? fm.removeItem(at: entry)
+            }
+        }
+    }
+}

--- a/Sources/Slotstream/DiskCache.swift
+++ b/Sources/Slotstream/DiskCache.swift
@@ -68,9 +68,34 @@ public enum DiskCache {
         return Int(gb * 1_073_741_824.0)
     }
 
-    /// Force the on-disk cache under its quota with the existing eviction
-    /// policy (`ChunkIndex.evictLeaves`): least recently valuable subtrees
-    /// first, leaves only, so a parent with live children is protected.
+    /// Turn-boundary saves: one node when a prompt finishes prefilling, one
+    /// when decode ends, each storing only the delta since the deepest node
+    /// the loader matched. A delta longer than its threshold splits into
+    /// chunk-boundary nodes plus a final partial, so one monster prompt or
+    /// generation cannot become one monster data.kv — the loader reads the
+    /// whole file into memory, and a multi-GB node is exactly what quota
+    /// eviction grabs wholesale. Splitting is ON by default (unset or invalid
+    /// → 0: every chunk boundary inside a delta becomes a node); a value
+    /// N ≥ 0 splits only deltas longer than N; a negative value disables
+    /// splitting. Purely env-driven, like the rest of the disk tier's knobs,
+    /// so offline gates stay hermetic.
+    static var promptSplitTokens: Int? {
+        splitThreshold("SLOTSTREAM_DISK_KV_SPLIT_LONG_PROMPTS")
+    }
+    /// Same for the post-decode delta.
+    static var decodeSplitTokens: Int? {
+        splitThreshold("SLOTSTREAM_DISK_KV_SPLIT_LONG_DECODES")
+    }
+    private static func splitThreshold(_ name: String) -> Int? {
+        guard let s = ProcessInfo.processInfo.environment[name], !s.isEmpty,
+              let v = Int(s) else { return 0 }
+        return v >= 0 ? v : nil
+    }
+
+    /// Force the on-disk cache under its quota with the eviction policy
+    /// (`ChunkIndex.evictLeaves`): oldest age tier first, leaves only, so a
+    /// freshly saved node is never the first thing evicted and a parent with
+    /// live children is protected.
     /// No-op while under quota. Returns bytes freed. Runs at startup when
     /// --kv-cache-size is given, and after every save.
     @discardableResult
@@ -444,14 +469,58 @@ public enum DiskCache {
         return depth == 0 ? nil : depth * chunk
     }
 
+    /// Follow variable-length children (turn-boundary nodes: one per prompt,
+    /// one per decode) as deep as the prompt's content verifies, starting at
+    /// the deepest fixed-boundary node (`parentSha`/`parentTokenCount`, both
+    /// root/0 when no fixed chain matched). Greedy longest-first, the same
+    /// trust model as the fixed chain walk: a candidate is accepted only when
+    /// the key re-derived from THIS prompt's delta embeddings matches its row,
+    /// so a stale or foreign index row can never alias content. Nodes are
+    /// extend-only — a candidate longer than the prompt is filtered out by
+    /// `childEndpoints(before:)`, and nothing ever rewinds.
+    /// Returns the accepted keys in chain order and the matched prefix end.
+    public static func longestVariableChain(
+        parentSha: String?,
+        parentTokenCount: Int,
+        promptCount: Int,
+        embedRange: (Int, Int) -> [Float]?,
+        maxVerifications: Int = 64
+    ) -> (keys: [String], end: Int) {
+        guard enabled else { return ([], parentTokenCount) }
+        var keys: [String] = []
+        var parent = parentSha
+        var pos = parentTokenCount
+        var verifications = 0
+        while pos < promptCount {
+            var advanced = false
+            for candidate in ChunkIndex.shared.childEndpoints(
+                parentSha: parent, parentTokenCount: pos, before: promptCount)
+            {
+                guard verifications < maxVerifications else { break }
+                guard let e = embedRange(pos, candidate.tokenCount) else { break }
+                verifications += 1
+                if ChunkIndex.makeKey(parentSha: parent, embeddings: e) == candidate.key {
+                    keys.append(candidate.key)
+                    parent = candidate.key
+                    pos = candidate.tokenCount
+                    advanced = true
+                    break
+                }
+            }
+            if !advanced { break }
+        }
+        return (keys, pos)
+    }
+
     // MARK: - load
 
-    /// Rebuild a state by applying `depth` fixed-size nodes and, when present,
-    /// one variable-length terminal child.
+    /// Rebuild a state by applying `depth` fixed-size nodes followed by the
+    /// variable-length turn nodes (prompt endpoints, decode endpoints) the
+    /// caller's chain walk verified.
     public static func loadState(
         for embed: (Int) -> [Float]?,
         depth: Int,
-        terminalKey: String? = nil,
+        variableKeys: [String] = [],
         tokenIds: [Int],
         template: Qwen4ExpModel.State
     ) -> Qwen4ExpModel.State? {
@@ -459,7 +528,7 @@ public enum DiskCache {
             log("load skipped: disk cache disabled")
             return nil
         }
-        guard depth > 0 || terminalKey != nil else {
+        guard depth > 0 || !variableKeys.isEmpty else {
             log("load failed: invalid chain depth \(depth)")
             return nil
         }
@@ -474,7 +543,7 @@ public enum DiskCache {
             keys.append(key)
             parentSha = key
         }
-        if let terminalKey { keys.append(terminalKey) }
+        keys.append(contentsOf: variableKeys)
 
         let state = template
         for (index, key) in keys.enumerated() {

--- a/Sources/Slotstream/Generate.swift
+++ b/Sources/Slotstream/Generate.swift
@@ -286,8 +286,109 @@ public final class Generator {
         let hit = cache?.take(
             matching: promptIds, images: images,
             reserveTokens: promptIds.count + params.maxTokens)
-        let state = hit?.state ?? model.makeState()
-        let reused = hit?.reused ?? 0
+        // Disk cache: try the longest chunk-aligned prefix on disk before the
+        // RAM cache — a cold conversation that was here before beats anything
+        // in flight. Guarded by enabled so a default run never opens the DB
+        // or the kvcache directory. Text-only: the disk key derives from token
+        // embeddings alone, which cannot see the vision tower's output, so a
+        // vision prompt skips the disk tier (and never saves to it below) and
+        // stays on the images-aware RAM path above.
+        let useDiskTier = DiskCache.enabled && images.isEmpty
+        var diskState: Qwen4ExpModel.State? = nil
+        var diskHitLen: Int? = nil
+        var diskParentKey: String? = nil
+        var diskParentTokenCount = 0
+        if useDiskTier {
+            let m = model
+            let pc = prefillChunk
+            // Embedding extractor: pull the embedding rows for chunk `d`
+            // (tokens [d*prefillChunk, (d+1)*prefillChunk)) on demand. The
+            // chain walk bails at the first miss so we never compute past
+            // the depth we actually consume.
+            let embed: (Int) -> [Float]? = { d in
+                let lo = d * pc
+                let hi = lo + pc
+                guard hi <= promptIds.count else { return nil }
+                let ids = MLXArray(promptIds[lo..<hi].map { Int32($0) }, [1, hi - lo])
+                let rows = m.resident.embed(ids).asType(.float32)
+                eval(rows)
+                return rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
+            }
+            if let l = DiskCache.longestPrefixHit(chunk: pc, embed: embed) {
+                for d in 0..<(l / pc) {
+                    guard let embeddings = embed(d) else { break }
+                    diskParentKey = ChunkIndex.makeKey(
+                        parentSha: diskParentKey, embeddings: embeddings)
+                }
+                diskParentTokenCount = l
+            }
+
+            // A decoded conversation endpoint is a variable-length child of
+            // the deepest fixed boundary (or of the root, when the whole
+            // conversation was shorter than one chunk). Test the longest possible
+            // endpoint first, and only accept one whose content-derived key matches.
+            var terminalKey: String? = nil
+            var terminalLen: Int? = nil
+            for candidate in ChunkIndex.shared.childEndpoints(
+                parentSha: diskParentKey, parentTokenCount: diskParentTokenCount,
+                before: promptIds.count)
+            {
+                let lo = diskParentTokenCount
+                let hi = candidate.tokenCount
+                if hi <= lo { continue }
+                let ids = MLXArray(promptIds[lo..<hi].map { Int32($0) }, [1, hi - lo])
+                let rows = m.resident.embed(ids).asType(.float32)
+                eval(rows)
+                let embeddings = rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
+                if ChunkIndex.makeKey(
+                    parentSha: diskParentKey, embeddings: embeddings) == candidate.key
+                {
+                    terminalKey = candidate.key
+                    terminalLen = hi
+                    break
+                }
+            }
+
+            let fixedLen = diskParentTokenCount
+            let loadLen = terminalLen ?? fixedLen
+            if loadLen > 0 {
+                let depth = fixedLen / pc
+                let curReused = hit?.reused ?? 0
+                if loadLen > curReused {
+                    var usedLen = loadLen
+                    var ds = DiskCache.loadState(
+                        for: embed, depth: depth, terminalKey: terminalKey,
+                        tokenIds: Array(promptIds[0..<loadLen]),
+                        template: model.makeState())
+                    // A stale or corrupt terminal must not hide a valid fixed
+                    // parent that was already proven by the chain walk.
+                    if ds == nil, terminalKey != nil, fixedLen > curReused {
+                        usedLen = fixedLen
+                        ds = DiskCache.loadState(
+                            for: embed, depth: depth,
+                            tokenIds: Array(promptIds[0..<fixedLen]),
+                            template: model.makeState())
+                    }
+                    if let ds {
+                        diskState = ds
+                        diskHitLen = usedLen
+                        FileHandle.standardError.write(
+                            "kvcache disk hit: \(usedLen)/\(promptIds.count) tokens\n".data(using: .utf8)!)
+                    }
+                }
+            }
+        }
+        let state: Qwen4ExpModel.State
+        let reused: Int
+        if let ds = diskState, let l = diskHitLen {
+            state = ds
+            reused = l
+            // Return the RAM hit state to the pool if we used disk instead
+            if let h = hit { cache?.store(state: h.state, tokens: Array(promptIds[0..<h.reused]), images: images) }
+        } else {
+            state = hit?.state ?? model.makeState()
+            reused = hit?.reused ?? 0
+        }
         stats.promptTokens = promptIds.count
         stats.reusedPrefixTokens = reused
         MLX.Memory.peakMemory = 0
@@ -311,7 +412,13 @@ public final class Generator {
         // main model actually saw. A state produced by a plain vision request
         // still runs plain, since its head cache would claim positions the
         // main state no longer matches.
-        let stateKnowsMTP = hit == nil || hit?.state.mtp != nil
+        //
+        // A disk-tier hit arrives with hit == nil but a state that already
+        // consumed tokens, so "no RAM hit" alone must not imply a fresh head:
+        // speculate only over a state whose draft cache actually covers it
+        // (offset == tokenCount - 1, the invariant the prefill loop keeps).
+        let stateKnowsMTP = reused == 0
+            || (state.mtp != nil && state.mtp!.offset == max(0, state.tokenCount - 1))
         let mtpHead = speculationEnabled && stateKnowsMTP ? model.mtpHead : nil
         if mtpHead != nil && state.mtp == nil { state.mtp = MTPState() }
         // Vision: the tower runs here and not at tokenize time, so an image the
@@ -373,6 +480,50 @@ public final class Generator {
                 let h = model.hiddenStates(chunk, state: state, vision: chunkVision)
                 eval(h)
             }
+            // Persist a chunk-aligned prefix for disk reuse. Done after the
+            // chunk compute so the state it captures is exactly what a future
+            // hit would reload. log() inside saveAsync tells us if/when it
+            // actually wrote — silent failure here is not acceptable.
+            // Text-only (see useDiskTier above): a vision state's KV carries
+            // tower output the embedding-derived key cannot fingerprint.
+            if useDiskTier, hi % prefillChunk == 0, hi < promptIds.count {
+                let depth = hi / prefillChunk
+                // Per-chunk embedding hash (not cumulative). The chain walk in
+                // DiskCache.longestPrefixHit produces
+                // `makeKey(parent: chain[d-1], embeddings: embed(d))`, so the
+                // save side has to match that shape: parent_sha comes from
+                // walking depths 0..<depth, the chunk embeddings are exactly
+                // the rows for tokens [(depth-1)*chunk .. depth*chunk].
+                let chunkLo = (depth - 1) * prefillChunk
+                let chunkHi = chunkLo + prefillChunk
+                let chunkIds = MLXArray(
+                    promptIds[chunkLo..<chunkHi].map { Int32($0) },
+                    [1, prefillChunk])
+                let chunkRows = model.resident.embed(chunkIds).asType(.float32)
+                eval(chunkRows)
+                let chunkEmbeds = chunkRows
+                    .reshaped([chunkRows.dim(1) * chunkRows.dim(2)])
+                    .asArray(Float.self)
+                var parentSha: String? = nil
+                for d in 0..<(depth - 1) {
+                    let lo = d * prefillChunk
+                    let hi2 = lo + prefillChunk
+                    guard hi2 <= promptIds.count else { break }
+                    let ids2 = MLXArray(
+                        promptIds[lo..<hi2].map { Int32($0) }, [1, prefillChunk])
+                    let r2 = model.resident.embed(ids2).asType(.float32)
+                    eval(r2)
+                    let e2 = r2.reshaped([r2.dim(1) * r2.dim(2)]).asArray(Float.self)
+                    parentSha = ChunkIndex.makeKey(parentSha: parentSha, embeddings: e2)
+                }
+                let key = ChunkIndex.makeKey(parentSha: parentSha, embeddings: chunkEmbeds)
+                DiskCache.saveAsync(
+                    state: state, tokenIds: Array(promptIds[0..<hi]),
+                    key: key, parentSha: parentSha, depth: depth,
+                    embeddings: chunkEmbeds, parentTokenCount: chunkLo)
+                diskParentKey = key
+                diskParentTokenCount = hi
+            }
             i = hi
             onPrefillProgress?(i - reused, promptIds.count - reused, -t0.timeIntervalSinceNow)
         }
@@ -425,6 +576,27 @@ public final class Generator {
             }
         }
         cache?.store(state: state, tokens: consumed, images: images)
+        // Conversation endpoints are rarely aligned to the prefill pass
+        // size. Save the terminal delta from the deepest fixed boundary so a
+        // later request that shares this conversation's prefix — even one
+        // that arrived exactly here — picks up where we stopped.
+        // Text-only (see useDiskTier above).
+        if useDiskTier, consumed.count > diskParentTokenCount {
+            let lo = diskParentTokenCount
+            let hi = consumed.count
+            let ids = MLXArray(consumed[lo..<hi].map { Int32($0) }, [1, hi - lo])
+            let rows = model.resident.embed(ids).asType(.float32)
+            eval(rows)
+            let embeddings = rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
+            let key = ChunkIndex.makeKey(
+                parentSha: diskParentKey, embeddings: embeddings)
+            DiskCache.saveAsync(
+                state: state, tokenIds: consumed, key: key,
+                parentSha: diskParentKey,
+                depth: diskParentTokenCount / prefillChunk + 1,
+                embeddings: embeddings,
+                parentTokenCount: diskParentTokenCount)
+        }
         stats.finishReason = reason
         stats.decodeTokens = out.count
         stats.decodeSeconds = -t0.timeIntervalSinceNow

--- a/Sources/Slotstream/Generate.swift
+++ b/Sources/Slotstream/Generate.swift
@@ -294,90 +294,98 @@ public final class Generator {
         // vision prompt skips the disk tier (and never saves to it below) and
         // stays on the images-aware RAM path above.
         let useDiskTier = DiskCache.enabled && images.isEmpty
+        let diskModel = model
+        let diskChunk = prefillChunk
+        // Embedding extractor for an arbitrary token range: the flat rows a
+        // node's key is derived from. The fixed chain walk slices it at chunk
+        // boundaries; turn nodes cover whatever range their delta spans.
+        // Walks bail at the first miss so nothing computes past the depth
+        // actually consumed.
+        let diskEmbedRange: (Int, Int) -> [Float]? = { lo, hi in
+            guard lo >= 0, lo < hi, hi <= promptIds.count else { return nil }
+            let ids = MLXArray(promptIds[lo..<hi].map { Int32($0) }, [1, hi - lo])
+            let rows = diskModel.resident.embed(ids).asType(.float32)
+            eval(rows)
+            return rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
+        }
         var diskState: Qwen4ExpModel.State? = nil
         var diskHitLen: Int? = nil
         var diskParentKey: String? = nil
         var diskParentTokenCount = 0
+        var diskChainDepth = 0
+        // Save one turn node covering [diskParentTokenCount, hi), chained
+        // onto the current deepest node, then advance the chain to it. The
+        // key is derived from the delta's own embeddings — the same
+        // re-derivation longestVariableChain uses to verify it on a later
+        // request. The write itself runs on DiskCache's serial save queue;
+        // the checkpoint is taken synchronously inside saveAsync, so a node
+        // saved at the prompt boundary holds exactly the post-prefill state.
+        func saveDiskNode(to hi: Int, state: Qwen4ExpModel.State, tokens: [Int]) {
+            let lo = diskParentTokenCount
+            guard lo < hi, let deltaEmbeds = diskEmbedRange(lo, hi) else { return }
+            let key = ChunkIndex.makeKey(parentSha: diskParentKey, embeddings: deltaEmbeds)
+            DiskCache.saveAsync(
+                state: state, tokenIds: Array(tokens[0..<hi]), key: key,
+                parentSha: diskParentKey, depth: diskChainDepth + 1,
+                embeddings: deltaEmbeds, parentTokenCount: lo)
+            diskParentKey = key
+            diskParentTokenCount = hi
+            diskChainDepth += 1
+        }
         if useDiskTier {
-            let m = model
-            let pc = prefillChunk
-            // Embedding extractor: pull the embedding rows for chunk `d`
-            // (tokens [d*prefillChunk, (d+1)*prefillChunk)) on demand. The
-            // chain walk bails at the first miss so we never compute past
-            // the depth we actually consume.
-            let embed: (Int) -> [Float]? = { d in
-                let lo = d * pc
-                let hi = lo + pc
-                guard hi <= promptIds.count else { return nil }
-                let ids = MLXArray(promptIds[lo..<hi].map { Int32($0) }, [1, hi - lo])
-                let rows = m.resident.embed(ids).asType(.float32)
-                eval(rows)
-                return rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
-            }
-            if let l = DiskCache.longestPrefixHit(chunk: pc, embed: embed) {
-                for d in 0..<(l / pc) {
-                    guard let embeddings = embed(d) else { break }
-                    diskParentKey = ChunkIndex.makeKey(
-                        parentSha: diskParentKey, embeddings: embeddings)
+            let pc = diskChunk
+            let embed: (Int) -> [Float]? = { d in diskEmbedRange(d * pc, (d + 1) * pc) }
+            // One retry: a node that fails to apply is invalidated and
+            // removed by the loader, so the second walk stops before it and
+            // the chain loads to its last valid ancestor. (The old
+            // terminal-only fallback was the depth-1 special case of this.)
+            for attempt in 0..<2 {
+                var fixedKey: String? = nil
+                var fixedLen = 0
+                if let l = DiskCache.longestPrefixHit(chunk: pc, embed: embed) {
+                    for d in 0..<(l / pc) {
+                        guard let e = embed(d) else { break }
+                        fixedKey = ChunkIndex.makeKey(parentSha: fixedKey, embeddings: e)
+                    }
+                    fixedLen = l
                 }
-                diskParentTokenCount = l
-            }
+                // Turn nodes (prompt endpoints, decode endpoints) extend the
+                // fixed chain as variable-length children, greedily
+                // longest-first, each verified against this prompt's content.
+                let variable = DiskCache.longestVariableChain(
+                    parentSha: fixedKey, parentTokenCount: fixedLen,
+                    promptCount: promptIds.count, embedRange: diskEmbedRange)
+                diskParentKey = variable.keys.last ?? fixedKey
+                diskParentTokenCount = variable.end
+                diskChainDepth = fixedLen / pc + variable.keys.count
 
-            // A decoded conversation endpoint is a variable-length child of
-            // the deepest fixed boundary (or of the root, when the whole
-            // conversation was shorter than one chunk). Test the longest possible
-            // endpoint first, and only accept one whose content-derived key matches.
-            var terminalKey: String? = nil
-            var terminalLen: Int? = nil
-            for candidate in ChunkIndex.shared.childEndpoints(
-                parentSha: diskParentKey, parentTokenCount: diskParentTokenCount,
-                before: promptIds.count)
-            {
-                let lo = diskParentTokenCount
-                let hi = candidate.tokenCount
-                if hi <= lo { continue }
-                let ids = MLXArray(promptIds[lo..<hi].map { Int32($0) }, [1, hi - lo])
-                let rows = m.resident.embed(ids).asType(.float32)
-                eval(rows)
-                let embeddings = rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
-                if ChunkIndex.makeKey(
-                    parentSha: diskParentKey, embeddings: embeddings) == candidate.key
+                let loadLen = variable.end
+                let curReused = hit?.reused ?? 0
+                if loadLen == 0 || loadLen <= curReused { break }
+                if let ds = DiskCache.loadState(
+                    for: embed, depth: fixedLen / pc, variableKeys: variable.keys,
+                    tokenIds: Array(promptIds[0..<loadLen]),
+                    template: model.makeState())
                 {
-                    terminalKey = candidate.key
-                    terminalLen = hi
+                    diskState = ds
+                    diskHitLen = loadLen
+                    FileHandle.standardError.write(
+                        "kvcache disk hit: \(loadLen)/\(promptIds.count) tokens\n".data(using: .utf8)!)
                     break
                 }
-            }
-
-            let fixedLen = diskParentTokenCount
-            let loadLen = terminalLen ?? fixedLen
-            if loadLen > 0 {
-                let depth = fixedLen / pc
-                let curReused = hit?.reused ?? 0
-                if loadLen > curReused {
-                    var usedLen = loadLen
-                    var ds = DiskCache.loadState(
-                        for: embed, depth: depth, terminalKey: terminalKey,
-                        tokenIds: Array(promptIds[0..<loadLen]),
-                        template: model.makeState())
-                    // A stale or corrupt terminal must not hide a valid fixed
-                    // parent that was already proven by the chain walk.
-                    if ds == nil, terminalKey != nil, fixedLen > curReused {
-                        usedLen = fixedLen
-                        ds = DiskCache.loadState(
-                            for: embed, depth: depth,
-                            tokenIds: Array(promptIds[0..<fixedLen]),
-                            template: model.makeState())
-                    }
-                    if let ds {
-                        diskState = ds
-                        diskHitLen = usedLen
-                        FileHandle.standardError.write(
-                            "kvcache disk hit: \(usedLen)/\(promptIds.count) tokens\n".data(using: .utf8)!)
-                    }
-                }
+                if attempt == 1 { break }
+                diskParentKey = nil
+                diskParentTokenCount = 0
+                diskChainDepth = 0
             }
         }
+        // A prompt delta longer than the split threshold becomes
+        // chunk-boundary nodes plus a final partial instead of one node.
+        let promptWillSplit = DiskCache.promptSplitTokens.map {
+            promptIds.count - diskParentTokenCount > $0
+        } ?? false
+        let decodeSplitThreshold = DiskCache.decodeSplitTokens
+
         let state: Qwen4ExpModel.State
         let reused: Int
         if let ds = diskState, let l = diskHitLen {
@@ -480,49 +488,16 @@ public final class Generator {
                 let h = model.hiddenStates(chunk, state: state, vision: chunkVision)
                 eval(h)
             }
-            // Persist a chunk-aligned prefix for disk reuse. Done after the
-            // chunk compute so the state it captures is exactly what a future
-            // hit would reload. log() inside saveAsync tells us if/when it
-            // actually wrote — silent failure here is not acceptable.
+            // Split a long prompt delta at chunk boundaries (only when
+            // SLOTSTREAM_DISK_KV_SPLIT_LONG_PROMPTS asks for it) so no single
+            // data.kv grows to the whole prompt. By default nothing is saved
+            // here: the prompt boundary itself is the save point below.
             // Text-only (see useDiskTier above): a vision state's KV carries
             // tower output the embedding-derived key cannot fingerprint.
-            if useDiskTier, hi % prefillChunk == 0, hi < promptIds.count {
-                let depth = hi / prefillChunk
-                // Per-chunk embedding hash (not cumulative). The chain walk in
-                // DiskCache.longestPrefixHit produces
-                // `makeKey(parent: chain[d-1], embeddings: embed(d))`, so the
-                // save side has to match that shape: parent_sha comes from
-                // walking depths 0..<depth, the chunk embeddings are exactly
-                // the rows for tokens [(depth-1)*chunk .. depth*chunk].
-                let chunkLo = (depth - 1) * prefillChunk
-                let chunkHi = chunkLo + prefillChunk
-                let chunkIds = MLXArray(
-                    promptIds[chunkLo..<chunkHi].map { Int32($0) },
-                    [1, prefillChunk])
-                let chunkRows = model.resident.embed(chunkIds).asType(.float32)
-                eval(chunkRows)
-                let chunkEmbeds = chunkRows
-                    .reshaped([chunkRows.dim(1) * chunkRows.dim(2)])
-                    .asArray(Float.self)
-                var parentSha: String? = nil
-                for d in 0..<(depth - 1) {
-                    let lo = d * prefillChunk
-                    let hi2 = lo + prefillChunk
-                    guard hi2 <= promptIds.count else { break }
-                    let ids2 = MLXArray(
-                        promptIds[lo..<hi2].map { Int32($0) }, [1, prefillChunk])
-                    let r2 = model.resident.embed(ids2).asType(.float32)
-                    eval(r2)
-                    let e2 = r2.reshaped([r2.dim(1) * r2.dim(2)]).asArray(Float.self)
-                    parentSha = ChunkIndex.makeKey(parentSha: parentSha, embeddings: e2)
-                }
-                let key = ChunkIndex.makeKey(parentSha: parentSha, embeddings: chunkEmbeds)
-                DiskCache.saveAsync(
-                    state: state, tokenIds: Array(promptIds[0..<hi]),
-                    key: key, parentSha: parentSha, depth: depth,
-                    embeddings: chunkEmbeds, parentTokenCount: chunkLo)
-                diskParentKey = key
-                diskParentTokenCount = hi
+            if useDiskTier, promptWillSplit,
+               hi % prefillChunk == 0, hi < promptIds.count
+            {
+                saveDiskNode(to: hi, state: state, tokens: promptIds)
             }
             i = hi
             onPrefillProgress?(i - reused, promptIds.count - reused, -t0.timeIntervalSinceNow)
@@ -545,6 +520,17 @@ public final class Generator {
         }
         model.pool.resetStats()
         model.ngram.resetStats()
+
+        // The prompt boundary is a turn node: one node holding everything
+        // since the deepest node the loader matched — for a cold conversation
+        // that is the whole prompt, for a continuing one only the new tokens.
+        // Saved before decode so the checkpoint it captures is exactly the
+        // post-prefill state (saveAsync checkpoints synchronously; the write
+        // is async on the save queue). The decode endpoint below then chains
+        // onto this node, so a turn costs only its own new tokens on disk.
+        if useDiskTier {
+            saveDiskNode(to: promptIds.count, state: state, tokens: promptIds)
+        }
 
         // ---- decode
         var out: [Int] = []
@@ -573,29 +559,29 @@ public final class Generator {
                 logits = model.lastLogits([tok], state: state)
                 consumed.append(tok)
                 eval(logits)
+                // Split a long decode delta at chunk boundaries (only when
+                // SLOTSTREAM_DISK_KV_SPLIT_LONG_DECODES asks for it). The
+                // state has consumed exactly `consumed.count` tokens here —
+                // a token is sampled before it is fed, and it was fed just
+                // above. The speculative path saves at decode end only: its
+                // state carries unverified draft tokens between rounds.
+                if let threshold = decodeSplitThreshold,
+                   consumed.count % diskChunk == 0,
+                   consumed.count - diskParentTokenCount > threshold
+                {
+                    saveDiskNode(to: consumed.count, state: state, tokens: consumed)
+                }
             }
         }
         cache?.store(state: state, tokens: consumed, images: images)
-        // Conversation endpoints are rarely aligned to the prefill pass
-        // size. Save the terminal delta from the deepest fixed boundary so a
-        // later request that shares this conversation's prefix — even one
-        // that arrived exactly here — picks up where we stopped.
-        // Text-only (see useDiskTier above).
-        if useDiskTier, consumed.count > diskParentTokenCount {
-            let lo = diskParentTokenCount
-            let hi = consumed.count
-            let ids = MLXArray(consumed[lo..<hi].map { Int32($0) }, [1, hi - lo])
-            let rows = model.resident.embed(ids).asType(.float32)
-            eval(rows)
-            let embeddings = rows.reshaped([rows.dim(1) * rows.dim(2)]).asArray(Float.self)
-            let key = ChunkIndex.makeKey(
-                parentSha: diskParentKey, embeddings: embeddings)
-            DiskCache.saveAsync(
-                state: state, tokenIds: consumed, key: key,
-                parentSha: diskParentKey,
-                depth: diskParentTokenCount / prefillChunk + 1,
-                embeddings: embeddings,
-                parentTokenCount: diskParentTokenCount)
+        // The decode endpoint is a turn node: the delta since the prompt
+        // node (or, when the prompt was a full hit, since that node itself).
+        // It chains onto the deepest saved node, so a later request that
+        // shares this conversation's prefix — even one that arrived exactly
+        // here — picks up where we stopped. Text-only (see useDiskTier
+        // above).
+        if useDiskTier {
+            saveDiskNode(to: consumed.count, state: state, tokens: consumed)
         }
         stats.finishReason = reason
         stats.decodeTokens = out.count

--- a/Sources/Slotstream/Layers.swift
+++ b/Sources/Slotstream/Layers.swift
@@ -115,6 +115,33 @@ final class KVCache {
     /// Roll back to `n` entries. Bytes past `n` stay in the buffer but are
     /// dead: the next update writes over them, and fetches slice 0..<offset.
     func trim(to n: Int) { offset = min(offset, max(0, n)) }
+
+    /// Adopt whole buffers (disk cache load). The running model's buffers are
+    /// replaced, not merged: the caller has already validated shape and dtype
+    /// against the config.
+    func restoreFromArrays(keys: MLXArray, values: MLXArray, offset: Int) {
+        self.keys = keys
+        self.values = values
+        self.offset = offset
+    }
+
+    /// Append one delta chunk (disk cache load). Rejects a shape/dtype that
+    /// cannot be grown into the existing buffer, so a corrupt node never
+    /// reaches the running state.
+    func append(keys k: MLXArray, values v: MLXArray) -> Bool {
+        guard k.ndim == 4, v.ndim == 4,
+              k.dim(0) == v.dim(0), k.dim(1) == v.dim(1),
+              k.dim(2) == v.dim(2), k.dim(3) == v.dim(3)
+        else { return false }
+        if let oldK = keys, let oldV = values {
+            guard oldK.dim(0) == k.dim(0), oldK.dim(1) == k.dim(1),
+                  oldK.dim(3) == k.dim(3), oldV.dim(0) == v.dim(0),
+                  oldV.dim(1) == v.dim(1), oldV.dim(3) == v.dim(3)
+            else { return false }
+        }
+        _ = updateAndFetch(k, v)
+        return true
+    }
 }
 
 /// Grown in blocks like KVCache rather than re-concatenated per token: a
@@ -124,6 +151,11 @@ final class IndexerCache {
     private var buf: MLXArray?  // (B, cap, dim)
     private(set) var offset = 0
     let step = 1024
+    func snapshot() -> MLXArray? { buf }
+    func restore(from arr: MLXArray, offset: Int) {
+        self.buf = arr
+        self.offset = offset
+    }
 
     func update(_ k: MLXArray) -> MLXArray {
         let s = k.dim(1)
@@ -142,6 +174,15 @@ final class IndexerCache {
 
     /// Roll back to `n` entries (see KVCache.trim).
     func trim(to n: Int) { offset = min(offset, max(0, n)) }
+
+    func append(_ arr: MLXArray) -> Bool {
+        guard arr.ndim == 3 else { return false }
+        if let old = buf {
+            guard old.dim(0) == arr.dim(0), old.dim(2) == arr.dim(2) else { return false }
+        }
+        _ = update(arr)
+        return true
+    }
 
     func materializeStorage() {
         if let b = buf { eval(b) }

--- a/Sources/Slotstream/Model.swift
+++ b/Sources/Slotstream/Model.swift
@@ -29,6 +29,13 @@ public final class Qwen4ExpModel {
         var linear: [Int: LinearCache] = [:]
         var kv: [Int: KVCache] = [:]
         var indexer: [Int: IndexerCache] = [:]
+        var expectedPLELayers: Set<Int> = []
+        var expectedConvShape: [Int] = []
+        var expectedSSMShape: [Int] = []
+        var expectedPLEShape: [Int] = []
+        var expectedKVHeads = 0
+        var expectedKVHeadDim = 0
+        var expectedIndexerDim = 0
         var ngramCtx: [Int64] = []
         public var tokenCount = 0
         /// Speculative-decode companions, created lazily by the MTP-aware
@@ -44,6 +51,10 @@ public final class Qwen4ExpModel {
     public init(index: CheckpointIndex, poolSlots: Int, runLayers: Int? = nil) throws {
         try ModelProcessGuard.acquire()
         self.cfg = index.config
+        // Namespace the disk KV cache to this checkout before anything can
+        // save or load: a same-shape weight swap must never serve stale KV
+        // built by different weights (see ChunkIndex.vault).
+        ChunkIndex.setVault(modelDir: index.dir)
         let selectedLayers = runLayers ?? index.config.numLayers
         guard selectedLayers >= 1, selectedLayers <= index.config.numLayers else {
             throw ModelError(
@@ -98,6 +109,19 @@ public final class Qwen4ExpModel {
 
     public func makeState() -> State {
         let s = State()
+        s.expectedPLELayers = Set(ple.keys)
+        s.expectedConvShape = [
+            1, cfg.convKernel - 1,
+            2 * cfg.linearNumKHeads * cfg.linearKHeadDim
+                + cfg.linearNumVHeads * cfg.linearVHeadDim]
+        s.expectedSSMShape = [
+            1, cfg.linearNumVHeads, cfg.linearVHeadDim, cfg.linearKHeadDim]
+        s.expectedPLEShape = [
+            1, (cfg.pleConvKernel - 1) * cfg.ngramSize,
+            cfg.hcCount * cfg.hiddenSize]
+        s.expectedKVHeads = cfg.numKVHeads
+        s.expectedKVHeadDim = cfg.headDim
+        s.expectedIndexerDim = cfg.indexerKVHeads * cfg.indexerHeadDim
         s.ngramCtx = Array(repeating: Int64(cfg.eosTokenId), count: cfg.ngramSize - 1)
         for l in 0 ..< runLayers {
             if cfg.layerTypes[l] == "linear_attention" {
@@ -250,12 +274,18 @@ public struct StateCheckpoint {
     var conv: [Int: MLXArray]
     var ssm: [Int: MLXArray]
     var pleConv: [Int: MLXArray]
+    var kv: [Int: (keys: MLXArray, values: MLXArray)]
+    var indexer: [Int: MLXArray]
     var kvOffsets: [Int: Int]
     var indexerOffsets: [Int: Int]
     var ngramCtx: [Int64]
     var tokenCount: Int
     var mtpOffset: Int
     var lastMulti: MLXArray?
+    var mtpKV: (MLXArray, MLXArray)?
+    var mtpIndexer: MLXArray?
+
+    var linearLayers: [Int] { conv.keys.sorted() }
 }
 
 extension Qwen4ExpModel.State {
@@ -263,17 +293,36 @@ extension Qwen4ExpModel.State {
         var conv: [Int: MLXArray] = [:]
         var ssm: [Int: MLXArray] = [:]
         var pleConv: [Int: MLXArray] = [:]
+        var kvArrays: [Int: (keys: MLXArray, values: MLXArray)] = [:]
+        var indexerArrays: [Int: MLXArray] = [:]
         for (l, c) in linear {
             if let a = c.convState { conv[l] = a }
             if let a = c.ssmState { ssm[l] = a }
             if let a = c.pleConvState { pleConv[l] = a }
         }
+        for (l, c) in kv {
+            if let k = c.keys, let v = c.values { kvArrays[l] = (k, v) }
+        }
+        for (l, c) in indexer {
+            if let b = c.snapshot() { indexerArrays[l] = b }
+        }
+        // MTP draft head KV/indexer carry the same persistent-state role as
+        // the main model's caches: their offsets are derived from the
+        // number of consumed positions, so save the buffers alongside.
+        var mtpKV: (MLXArray, MLXArray)? = nil
+        var mtpIdx: MLXArray? = nil
+        if let m = mtp, let k = m.kv.keys, let v = m.kv.values {
+            mtpKV = (k, v)
+            mtpIdx = m.indexer.snapshot()
+        }
         return StateCheckpoint(
             conv: conv, ssm: ssm, pleConv: pleConv,
+            kv: kvArrays, indexer: indexerArrays,
             kvOffsets: kv.mapValues { $0.offset },
             indexerOffsets: indexer.mapValues { $0.offset },
             ngramCtx: ngramCtx, tokenCount: tokenCount,
-            mtpOffset: mtp?.offset ?? 0, lastMulti: lastMulti)
+            mtpOffset: mtp?.offset ?? 0, lastMulti: lastMulti,
+            mtpKV: mtpKV, mtpIndexer: mtpIdx)
     }
 
     /// Start or stop recording per-position recurrent states in the linear
@@ -344,6 +393,13 @@ extension Qwen4ExpModel.State {
         tokenCount = c.tokenCount
         mtp?.trim(to: c.mtpOffset)
         lastMulti = c.lastMulti
+        // Restore the MTP draft head's KV/indexer in lockstep with its offset,
+        // otherwise the next consume() writes at row 0 while rope expects
+        // position tokenCount-1 — exactly the trap that segfaulted before.
+        if let m = mtp, let (k, v) = c.mtpKV {
+            m.kv.restoreFromArrays(keys: k, values: v, offset: c.mtpOffset)
+            if let b = c.mtpIndexer { m.indexer.restore(from: b, offset: c.mtpOffset) }
+        }
     }
 }
 

--- a/Sources/SlotstreamDiagnostics/Diagnostics+Runtime.swift
+++ b/Sources/SlotstreamDiagnostics/Diagnostics+Runtime.swift
@@ -96,6 +96,43 @@ extension Diagnostics {
             "a disabled prefix cache offers no splice",
             spliceCache.peek(extending: [7]) == nil)
 
+        // Disk quota enforcement (the --kv-cache-size path), weights-free:
+        // a fake leaf with a v4 data.kv and an index row must leave the DB
+        // AND the disk when a smaller quota forces eviction, and lookup must
+        // not resurrect it through the unindexed-but-on-disk heal path.
+        let kvDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "slotstream-runtimecheck-kv-\(Int(Date().timeIntervalSince1970 * 1000))",
+                isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: kvDir, withIntermediateDirectories: true)
+        DiskCache.dirOverride = kvDir.path
+        defer {
+            try? FileManager.default.removeItem(at: kvDir)
+            DiskCache.dirOverride = nil
+            DiskCache.maxBytesOverride = nil
+        }
+        let emb: [Float] = [0.5, -0.25, 1.0, 0.125]
+        let key = ChunkIndex.makeKey(parentSha: nil, embeddings: emb)
+        let chunkDir = kvDir.appendingPathComponent(key, isDirectory: true)
+        try? FileManager.default.createDirectory(at: chunkDir, withIntermediateDirectories: true)
+        try? Data("{\"version\":4}\n".utf8).write(
+            to: chunkDir.appendingPathComponent("data.kv"))
+        ChunkIndex.shared.register(
+            key: key, parentSha: nil, depth: 0,
+            parentTokenCount: 0, tokenCount: 128, sizeBytes: 1_000_000)
+        DiskCache.maxBytesOverride = 1e-6  // ~1 KB: the 1 MB chunk is over quota
+        let freed = DiskCache.enforceQuota()
+        c.expect("forced eviction frees an over-quota leaf", freed >= 1_000_000)
+        c.expect(
+            "an evicted leaf's directory leaves the disk",
+            !FileManager.default.fileExists(
+                atPath: chunkDir.appendingPathComponent("data.kv").path))
+        let resurrected = DiskCache.longestPrefixHit(
+            chunk: 128, embed: { d in d == 0 ? emb : nil })
+        c.expect("lookup does not resurrect an evicted chunk", resurrected == nil)
+        DiskCache.maxBytesOverride = nil
+
         // Weights behind a symlink: Foundation refuses to list the link itself,
         // so the index must resolve it first (it did not, before 0.2.1).
         let tmp = FileManager.default.temporaryDirectory

--- a/Sources/SlotstreamDiagnostics/Diagnostics+Runtime.swift
+++ b/Sources/SlotstreamDiagnostics/Diagnostics+Runtime.swift
@@ -133,6 +133,134 @@ extension Diagnostics {
         c.expect("lookup does not resurrect an evicted chunk", resurrected == nil)
         DiskCache.maxBytesOverride = nil
 
+        // Turn-boundary chains (one variable node per prompt, one per decode)
+        // are walked by longestVariableChain over childEndpoints from the
+        // deepest fixed boundary, each candidate re-verified against THIS
+        // prompt's delta embeddings. Weights-free: synthetic embeddings stand
+        // in for the model's — only key derivation, index rows and the
+        // placeholder data.kv files matter. Fixed chain: two chunks of 128;
+        // turn chain: prompt node at 300, decode node at 340, plus a foreign
+        // row registered past the end whose content cannot re-derive.
+        func registerNode(parent: String?, lo: Int, hi: Int, _ e: [Float]) -> String {
+            let k = ChunkIndex.makeKey(parentSha: parent, embeddings: e)
+            ChunkIndex.shared.register(
+                key: k, parentSha: parent, depth: 0,
+                parentTokenCount: lo, tokenCount: hi, sizeBytes: 16)
+            let nodeDir = kvDir.appendingPathComponent(k, isDirectory: true)
+            try? FileManager.default.createDirectory(
+                at: nodeDir, withIntermediateDirectories: true)
+            try? Data("{\"version\":4}\n".utf8).write(
+                to: nodeDir.appendingPathComponent("data.kv"))
+            return k
+        }
+        let emb0: [Float] = [0.5, -0.25, 1.0, 0.125]
+        let emb1: [Float] = [1.5, 0.25, -1.0, 0.5]
+        let turn0: [Float] = [2.0, 1.0, -0.5, 0.25]
+        let turn1: [Float] = [0.125, -1.0, 2.0, 0.75]
+        let rootKey = registerNode(parent: nil, lo: 0, hi: 128, emb0)
+        let chunkKey = registerNode(parent: rootKey, lo: 128, hi: 256, emb1)
+        let promptNodeKey = registerNode(parent: chunkKey, lo: 256, hi: 300, turn0)
+        let decodeNodeKey = registerNode(parent: promptNodeKey, lo: 300, hi: 340, turn1)
+        _ = registerNode(parent: decodeNodeKey, lo: 340, hi: 360, [9.0, 9.0, 9.0, 9.0])
+        let fakeEmbed: (Int, Int) -> [Float]? = { lo, hi in
+            switch (lo, hi) {
+            case (0, 128): return emb0
+            case (128, 256): return emb1
+            case (256, 300): return turn0
+            case (300, 340): return turn1
+            default: return [3.0, 3.0, 3.0, 3.0]
+            }
+        }
+        let fixed = DiskCache.longestPrefixHit(
+            chunk: 128, embed: { d in d == 0 ? emb0 : d == 1 ? emb1 : nil })
+        c.equal("fixed chain walk still reaches its boundary nodes", fixed, 256)
+        let chain = DiskCache.longestVariableChain(
+            parentSha: chunkKey, parentTokenCount: 256, promptCount: 380,
+            embedRange: fakeEmbed)
+        c.expect(
+            "turn chain walks the prompt node then the decode node",
+            chain.keys == [promptNodeKey, decodeNodeKey])
+        c.equal(
+            "turn chain ends at the last content-verified node", chain.end, 340)
+        c.expect(
+            "a foreign child never verifies, even with a matching boundary",
+            DiskCache.longestVariableChain(
+                parentSha: decodeNodeKey, parentTokenCount: 340, promptCount: 380,
+                embedRange: fakeEmbed).keys.isEmpty)
+        let short = DiskCache.longestVariableChain(
+            parentSha: chunkKey, parentTokenCount: 256, promptCount: 320,
+            embedRange: fakeEmbed)
+        c.expect(
+            "a prompt shorter than a held node stops below it, never rewinds",
+            short.keys == [promptNodeKey] && short.end == 300)
+        let cold = DiskCache.longestVariableChain(
+            parentSha: nil, parentTokenCount: 0, promptCount: 380,
+            embedRange: { _, _ in nil })
+        c.expect(
+            "a walk without embeddings verifies nothing",
+            cold.keys.isEmpty && cold.end == 0)
+
+        // A dead conversation is now a deep chain, and one eviction pass can
+        // only see its current tip: quota enforcement must iterate until the
+        // whole chain is gone (it used to free one node per pass).
+        var chainPrev: String? = nil
+        var deepChainKeys: [String] = []
+        for i in 0..<4 {
+            let k = registerNode(
+                parent: chainPrev, lo: i * 10, hi: (i + 1) * 10,
+                [Float(i + 10), 0.5, -0.5, 1.5])
+            ChunkIndex.shared.register(
+                key: k, parentSha: chainPrev, depth: i,
+                parentTokenCount: i * 10, tokenCount: (i + 1) * 10,
+                sizeBytes: 1_000_000)
+            deepChainKeys.append(k)
+            chainPrev = k
+        }
+        DiskCache.maxBytesOverride = 1e-6
+        let freedDeep = DiskCache.enforceQuota()
+        c.expect("quota enforcement eats a dead turn chain to its root", freedDeep >= 4_000_000)
+        c.expect(
+            "every node of the dead chain left the disk",
+            deepChainKeys.allSatisfy {
+                !FileManager.default.fileExists(
+                    atPath: kvDir.appendingPathComponent($0, isDirectory: true)
+                        .appendingPathComponent("data.kv").path)
+            })
+        DiskCache.maxBytesOverride = nil
+
+        // Recency must outrank depth. A leaf saved seconds after its elders
+        // sits in the youngest age tier and survives a deficit those elders
+        // cover; under plain depth-first ordering the fresh depth-0 leaf went
+        // first, which is how the saver evicted the node it had just written
+        // (a live conversation's tip is also its shallowest leaf).
+        var agePrev: String? = nil
+        var ageTip = ""
+        for i in 0..<4 {
+            ageTip = registerNode(
+                parent: agePrev, lo: 100 + i * 10, hi: 110 + i * 10,
+                [Float(i + 40), 0.5, -0.5, 1.5])
+            ChunkIndex.shared.register(
+                key: ageTip, parentSha: agePrev, depth: i,
+                parentTokenCount: 100 + i * 10, tokenCount: 110 + i * 10,
+                sizeBytes: 1_000_000)
+            agePrev = ageTip
+        }
+        let freshKey = registerNode(parent: nil, lo: 200, hi: 210, [7.0, 0.5, -0.5, 1.5])
+        ChunkIndex.shared.register(
+            key: freshKey, parentSha: nil, depth: 0,
+            parentTokenCount: 200, tokenCount: 210, sizeBytes: 1_000_000)
+        // Total ≈ 5 MB of rows; the quota leaves a deficit smaller than one
+        // node — exactly the shape of the reported bug.
+        DiskCache.maxBytesOverride = 4_200_000.0 / 1_073_741_824.0
+        _ = DiskCache.enforceQuota()
+        c.expect(
+            "an old deep tip is evicted before a fresh shallow leaf",
+            !ChunkIndex.shared.contains(key: ageTip))
+        c.expect(
+            "the freshest leaf survives a deficit its elders cover",
+            ChunkIndex.shared.contains(key: freshKey))
+        DiskCache.maxBytesOverride = nil
+
         // Weights behind a symlink: Foundation refuses to list the link itself,
         // so the index must resolve it first (it did not, before 0.2.1).
         let tmp = FileManager.default.temporaryDirectory

--- a/Sources/slotstream-cli/main.swift
+++ b/Sources/slotstream-cli/main.swift
@@ -117,6 +117,51 @@ struct ModelOptions: ParsableArguments {
                 """))
     var vision: String = "auto"
 
+    @Option(
+        help: ArgumentHelp(
+            "Where the on-disk prefix KV cache lives (default ~/.slotstream/kvcache).",
+            discussion: """
+                Overrides the env var SLOTSTREAM_KVCACHE_DIR for this run only. \
+                Used by the prefix-cache disk tier; a parent-chained index is \
+                kept at <dir>/metadata.db. Passing it enables the disk tier \
+                for this invocation.
+                """))
+    var diskKVCache: String?
+
+    @Option(
+        name: .customLong("disk-kv-cache-size"),
+        help: ArgumentHelp(
+            "On-disk prefix KV cache quota (e.g. 2048, 2048M, 2G; no suffix means MB.",
+            discussion: """
+                Sets the quota for this run — overriding \
+                SLOTSTREAM_KVCACHE_MAX_GB — and immediately evicts the \
+                least valuable leaf chunks until the store fits, before the \
+                model loads. The value is a size with an optional G/GB or \
+                M/MB suffix (case-insensitive); no suffix means megabytes. \
+                Same policy the save path applies: chunks are valued by the \
+                newest use anywhere in their subtree, so a parent with live \
+                children is protected, and only leaves are ever dropped. \
+                Values below one chunk's footprint make the disk tier \
+                ineffective.
+                """))
+    var diskKVCacheSize: String?
+
+    /// The disk quota in GB parsed from `--disk-kv-cache-size`: an optional
+    /// G / GB or M / MB suffix (case-insensitive), no suffix means megabytes.
+    /// nil when the flag is absent or unparseable.
+    var kvCacheSizeGB: Double? {
+        guard let raw = diskKVCacheSize else { return nil }
+        var s = raw.trimmingCharacters(in: .whitespaces)
+        let upper = s.uppercased()
+        var multiplierMB = 1.0
+        if upper.hasSuffix("GB") { s = String(s.dropLast(2)); multiplierMB = 1024.0 }
+        else if upper.hasSuffix("MB") { s = String(s.dropLast(2)) }
+        else if upper.hasSuffix("G") { s = String(s.dropLast(1)); multiplierMB = 1024.0 }
+        else if upper.hasSuffix("M") { s = String(s.dropLast(1)) }
+        guard let mb = Double(s) else { return nil }
+        return mb * multiplierMB / 1024.0
+    }
+
     // Resolved once here so the tokenizer, the draft-head probe, and the index
     // all see the real directory; Foundation will not list a symlinked one.
     var modelURL: URL { ModelLocator.resolve(model).resolvingSymlinksInPath() }
@@ -144,7 +189,31 @@ struct ModelOptions: ParsableArguments {
     /// Resolve knobs -> plan, print the announce, return it. Also the first
     /// place a stranger hits with no weights — offer the download right there.
     func announcedPlan(maxContext: Int = ContextPolicy.maxTokens) throws -> MemoryPlan {
+        if diskKVCacheSize != nil, let gb = kvCacheSizeGB, !gb.isFinite || gb <= 0 {
+            throw PlanError("--disk-kv-cache-size must be a size greater than 0 (MB, or with a G/GB or M/MB suffix) (got \(diskKVCacheSize ?? ""))")
+        }
+        if diskKVCacheSize != nil, kvCacheSizeGB == nil {
+            throw PlanError("--disk-kv-cache-size must be a size in MB, optionally with a G/GB or M/MB suffix (got \(diskKVCacheSize ?? ""))")
+        }
         try ensureWeights()
+        // Apply explicit --disk-kv-cache before any code reads DiskCache.dir.
+        // The env-var path is the fallback inside DiskCache.dir itself.
+        if let d = diskKVCache, !d.isEmpty {
+            DiskCache.dirOverride = d
+        }
+        // --disk-kv-cache-size sets the quota and forces the store under it
+        // right here, before the model loads and before anything can save.
+        if let gb = kvCacheSizeGB {
+            DiskCache.maxBytesOverride = gb
+            let freed = DiskCache.enforceQuota()
+            let total = ChunkIndex.shared.totalBytes()
+            let note = freed > 0
+                ? String(format: ", evicted %.2f GB leaf-first", Double(freed) / 1e9)
+                : ", already under quota"
+            FileHandle.standardError.write(
+                Data(String(format: "disk-kv-cache-size %.1f GB: store is %.2f GB%@\n",
+                            gb, Double(total) / 1e9, note).utf8))
+        }
         let plan = try Planner.plan(
             expertsPerLayer: expertsPerLayer, poolGB: poolGB, memoryGB: memoryGB,
             ramPercent: maxRAMPercent,


### PR DESCRIPTION
Lets you persist KV cache on disk, so you don't have to rerun prefill every time you close and start slotstream. Also lets you rewind + branch out which you can't do with PrefixCache.swift.

Disabled by default, enabled by --disk-kv-cache /path/to/file and optionally --disk-kv-cache-size (bounded to your free storage otherwise).

Works by persisting 4096 tokens at a time (in separate files), eviction of leaves in the shortest prefixes with LRU for tie breaking.

---

Disclaimers:
- Purely vibecoded so merge at your own discretion. I'm placing this here in case you feel like reviewing, or in case this is helpful to anyone. I'll respond to fix requests of course.
- Used an LLM to port this out of a [my fork](https://github.com/msx98/slotstream) which contains more stuff (vision, tool calls, disk kv, expert prefetching etc) which I'll port over in other PRs. I did stress test the larger branch thoroughly but not this one. I'll undraft after testing or if anyone feels like doing it.